### PR TITLE
Add Discord patches

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ c2-wrapper = ["backend"]
 [dependencies]
 anyhow = { version = "1.0.75", optional = true }
 byteorder = { version = "1.4.3", optional = true }
-libva = { version = "0.0.12", package = "cros-libva", optional = true }
+libva = { version = "0.0.13", package = "cros-libva", optional = true }
 v4l2r = { version = "0.0.5", package = "v4l2r", optional = true }
 log = { version = "0", features = ["release_max_level_debug"] }
 thiserror = { version = "1.0.58", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,9 +9,13 @@ edition = "2021"
 
 [features]
 default = []
-backend = ["anyhow", "byteorder", "thiserror", "crc32fast", "nix", "gbm", "gbm-sys", "drm", "drm-fourcc", "zerocopy"]
+backend = ["anyhow", "byteorder", "thiserror", "crc32fast", "nix", "drm", "drm-fourcc", "zerocopy"]
 vaapi = ["libva", "backend"]
 v4l2 = ["v4l2r", "backend"]
+gbm = ["dep:gbm", "gbm-sys"]
+h265 = []
+av1 = []
+c2-wrapper = ["backend"]
 
 [dependencies]
 anyhow = { version = "1.0.75", optional = true }

--- a/src/backend/v4l2/encoder.rs
+++ b/src/backend/v4l2/encoder.rs
@@ -523,6 +523,7 @@ where
             "bitrate mode",
             match rate_control {
                 RateControl::ConstantBitrate(_) => VideoBitrateMode::ConstantBitrate,
+                RateControl::VariableBitrate { .. } => todo!(),
                 RateControl::ConstantQuality(_) => VideoBitrateMode::ConstantQuality,
             },
         )?;

--- a/src/backend/v4l2/encoder.rs
+++ b/src/backend/v4l2/encoder.rs
@@ -1217,6 +1217,7 @@ pub(crate) mod tests {
                 timestamp: self.counter,
                 layout: self.frame_layout.clone(),
                 force_keyframe: false,
+                force_idr: false,
             };
 
             let handle = TestMmapFrame { meta: meta.clone(), frame_count: self.max_count };
@@ -1326,6 +1327,7 @@ pub(crate) mod tests {
                 timestamp: self.counter,
                 layout: layout.clone(),
                 force_keyframe: false,
+                force_idr: false,
             };
 
             let frame = DmabufFrame { fds, layout };

--- a/src/backend/vaapi/decoder.rs
+++ b/src/backend/vaapi/decoder.rs
@@ -191,7 +191,7 @@ impl<V: VideoFrame> VaapiDecodedHandle<V> {
 }
 
 pub struct VaapiBackend<V: VideoFrame> {
-    pub display: Rc<Display>,
+    pub display: Arc<Display>,
     pub context: Rc<Context>,
     stream_info: StreamInfo,
     // TODO: We should try to support context reuse
@@ -200,7 +200,7 @@ pub struct VaapiBackend<V: VideoFrame> {
 }
 
 impl<V: VideoFrame> VaapiBackend<V> {
-    pub(crate) fn new(display: Rc<libva::Display>, supports_context_reuse: bool) -> Self {
+    pub(crate) fn new(display: Arc<libva::Display>, supports_context_reuse: bool) -> Self {
         let init_stream_info = StreamInfo {
             format: DecodedFormat::NV12,
             coded_resolution: Resolution::from((16, 16)),

--- a/src/backend/vaapi/encoder.rs
+++ b/src/backend/vaapi/encoder.rs
@@ -309,6 +309,21 @@ where
         }
         Ok(true)
     }
+
+    pub(crate) fn supports_packed_header(&self, header: u32) -> StatelessBackendResult<bool> {
+        let display = self.context().display();
+        let mut attrs = [libva::VAConfigAttrib {
+            type_: libva::VAConfigAttribType::VAConfigAttribEncPackedHeaders,
+            value: 0,
+        }];
+
+        display.get_config_attributes(self.va_profile, self.entrypoint, &mut attrs)?;
+
+        if attrs[0].value == libva::VA_ATTRIB_NOT_SUPPORTED || (header & attrs[0].value) == 0 {
+            return Ok(false);
+        }
+        Ok(true)
+    }
 }
 
 impl<M, Handle> StatelessEncoderBackendImport<Handle, Handle> for VaapiBackend<M, Handle>

--- a/src/backend/vaapi/encoder.rs
+++ b/src/backend/vaapi/encoder.rs
@@ -491,6 +491,7 @@ pub(crate) mod tests {
                 layout: self.frame_layout.clone(),
                 force_keyframe: false,
                 timestamp: self.counter,
+                force_idr: false,
             };
 
             self.counter += 1;

--- a/src/backend/vaapi/encoder.rs
+++ b/src/backend/vaapi/encoder.rs
@@ -53,11 +53,14 @@ impl From<libva::VaError> for StatelessBackendError {
 pub(crate) fn tunings_to_libva_rc<const CLAMP_MIN_QP: u32, const CLAMP_MAX_QP: u32>(
     tunings: &Tunings,
 ) -> StatelessBackendResult<libva::EncMiscParameterRateControl> {
-    let bits_per_second = tunings.rate_control.bitrate_target().unwrap_or(0);
-    let bits_per_second = u32::try_from(bits_per_second).map_err(|e| anyhow::anyhow!(e))?;
+    let bits_per_second = tunings.rate_control.bitrate_maximum().unwrap_or(0);
+    let target_bits_per_second = tunings.rate_control.bitrate_target().unwrap_or(bits_per_second);
 
-    // At the moment we don't support variable bitrate therefore target 100%
-    const TARGET_PERCENTAGE: u32 = 100;
+    let bits_per_second = u32::try_from(bits_per_second).map_err(|e| anyhow::anyhow!(e))?;
+    let target_bits_per_second =
+        u32::try_from(target_bits_per_second).map_err(|e| anyhow::anyhow!(e))?;
+
+    let target_percentage: u32 = 100 * target_bits_per_second / bits_per_second;
 
     // Window size in ms that the RC should apply to
     const WINDOW_SIZE: u32 = 1_500;
@@ -114,7 +117,7 @@ pub(crate) fn tunings_to_libva_rc<const CLAMP_MIN_QP: u32, const CLAMP_MAX_QP: u
 
     Ok(libva::EncMiscParameterRateControl::new(
         bits_per_second,
-        TARGET_PERCENTAGE,
+        target_percentage,
         WINDOW_SIZE,
         initial_qp,
         min_qp,

--- a/src/backend/vaapi/encoder.rs
+++ b/src/backend/vaapi/encoder.rs
@@ -294,6 +294,21 @@ where
         }
         Ok(true)
     }
+
+    pub(crate) fn supports_quality_range(&self, quality: u32) -> StatelessBackendResult<bool> {
+        let display = self.context().display();
+        let mut attrs = [libva::VAConfigAttrib {
+            type_: libva::VAConfigAttribType::VAConfigAttribEncQualityRange,
+            value: 0,
+        }];
+
+        display.get_config_attributes(self.va_profile, self.entrypoint, &mut attrs)?;
+
+        if attrs[0].value == libva::VA_ATTRIB_NOT_SUPPORTED || quality > attrs[0].value {
+            return Ok(false);
+        }
+        Ok(true)
+    }
 }
 
 impl<M, Handle> StatelessEncoderBackendImport<Handle, Handle> for VaapiBackend<M, Handle>

--- a/src/backend/vaapi/encoder.rs
+++ b/src/backend/vaapi/encoder.rs
@@ -18,6 +18,7 @@ use libva::PictureEnd;
 use libva::Surface;
 use libva::SurfaceMemoryDescriptor;
 use libva::UsageHint;
+use libva::VAEntrypoint;
 use libva::VAEntrypoint::VAEntrypointEncSlice;
 use libva::VAEntrypoint::VAEntrypointEncSliceLP;
 use libva::VAProfile;
@@ -165,7 +166,8 @@ where
     /// VA context used for encoding.
     context: Rc<Context>,
 
-    _va_profile: VAProfile::Type,
+    va_profile: VAProfile::Type,
+    entrypoint: VAEntrypoint::Type,
     scratch_pool: VaSurfacePool<()>,
     _phantom: PhantomData<(M, H)>,
 }
@@ -189,6 +191,7 @@ where
             .ok_or_else(|| StatelessBackendError::UnsupportedFormat)?;
 
         let rt_format = format_map.rt_format;
+        let entrypoint = if low_power { VAEntrypointEncSliceLP } else { VAEntrypointEncSlice };
 
         let va_config = display.create_config(
             vec![
@@ -202,7 +205,7 @@ where
                 },
             ],
             va_profile,
-            if low_power { VAEntrypointEncSliceLP } else { VAEntrypointEncSlice },
+            entrypoint,
         )?;
 
         let context = display.create_context::<M>(
@@ -227,7 +230,8 @@ where
             va_config,
             context,
             scratch_pool,
-            _va_profile: va_profile,
+            va_profile,
+            entrypoint,
             _phantom: Default::default(),
         })
     }
@@ -274,6 +278,21 @@ where
             self.scratch_pool.get_surface().ok_or(StatelessBackendError::OutOfResources)?;
 
         Ok(Reconstructed(surface))
+    }
+
+    pub(crate) fn supports_max_frame_size(&self) -> StatelessBackendResult<bool> {
+        let display = self.context().display();
+        let mut attrs = [libva::VAConfigAttrib {
+            type_: libva::VAConfigAttribType::VAConfigAttribMaxFrameSize,
+            value: 0,
+        }];
+
+        display.get_config_attributes(self.va_profile, self.entrypoint, &mut attrs)?;
+
+        if attrs[0].value == libva::VA_ATTRIB_NOT_SUPPORTED {
+            return Ok(false);
+        }
+        Ok(true)
     }
 }
 

--- a/src/backend/vaapi/encoder.rs
+++ b/src/backend/vaapi/encoder.rs
@@ -5,6 +5,7 @@
 use std::any::Any;
 use std::marker::PhantomData;
 use std::rc::Rc;
+use std::sync::Arc;
 
 use anyhow::anyhow;
 use libva::Config;
@@ -172,7 +173,7 @@ where
     H: std::borrow::Borrow<Surface<M>>,
 {
     pub fn new(
-        display: Rc<Display>,
+        display: Arc<Display>,
         va_profile: VAProfile::Type,
         fourcc: Fourcc,
         coded_size: Resolution,
@@ -210,7 +211,7 @@ where
         )?;
 
         let mut scratch_pool = VaSurfacePool::new(
-            Rc::clone(&display),
+            Arc::clone(&display),
             rt_format,
             Some(UsageHint::USAGE_HINT_ENCODER),
             coded_size,

--- a/src/backend/vaapi/encoder.rs
+++ b/src/backend/vaapi/encoder.rs
@@ -74,10 +74,10 @@ pub(crate) fn tunings_to_libva_rc<const CLAMP_MIN_QP: u32, const CLAMP_MAX_QP: u
     const RESET: u32 = 0;
 
     // Don't skip frames
-    const DISABLE_FRAME_SKIP: u32 = 1;
+    const DISABLE_FRAME_SKIP: u32 = 0;
 
     // Allow bit stuffing
-    const DISABLE_BIT_STUFFING: u32 = 0;
+    const DISABLE_BIT_STUFFING: u32 = 1;
 
     // Use default
     const MB_RATE_CONTROL: u32 = 0;

--- a/src/backend/vaapi/surface_pool.rs
+++ b/src/backend/vaapi/surface_pool.rs
@@ -8,6 +8,7 @@ use std::collections::BTreeMap;
 use std::collections::VecDeque;
 use std::rc::Rc;
 use std::rc::Weak;
+use std::sync::Arc;
 
 use libva::Display;
 use libva::Surface;
@@ -79,7 +80,7 @@ impl<M: SurfaceMemoryDescriptor> Drop for PooledVaSurface<M> {
 }
 
 struct VaSurfacePoolInner<M: SurfaceMemoryDescriptor> {
-    display: Rc<Display>,
+    display: Arc<Display>,
     rt_format: u32,
     usage_hint: Option<libva::UsageHint>,
     coded_resolution: Resolution,
@@ -133,7 +134,7 @@ impl<M: SurfaceMemoryDescriptor> VaSurfacePool<M> {
     /// * `usage_hint` - hint about how the surfaces from this pool will be used.
     /// * `coded_resolution` - resolution of the surfaces.
     pub fn new(
-        display: Rc<Display>,
+        display: Arc<Display>,
         rt_format: u32,
         usage_hint: Option<libva::UsageHint>,
         coded_resolution: Resolution,

--- a/src/bitstream_utils.rs
+++ b/src/bitstream_utils.rs
@@ -510,15 +510,18 @@ impl<W: Write> BitWriter<W> {
     }
 
     /// Immediately outputs any cached bits to [`std::io::Write`]
-    pub fn flush(&mut self) -> BitWriterResult<()> {
+    /// and returns the number of trailing bits in the last byte.
+    pub fn flush(&mut self) -> BitWriterResult<u8> {
+        let mut num_trailing_bits = 0;
         if self.nth_bit != 0 {
             self.out.write_all(&[self.curr_byte])?;
+            num_trailing_bits = 8 - self.nth_bit;
             self.nth_bit = 0;
             self.curr_byte = 0;
         }
 
         self.out.flush()?;
-        Ok(())
+        Ok(num_trailing_bits)
     }
 
     /// Returns `true` if ['Self`] hold data that wasn't written to [`std::io::Write`]

--- a/src/c2_wrapper/c2_decoder.rs
+++ b/src/c2_wrapper/c2_decoder.rs
@@ -32,7 +32,7 @@ use crate::decoder::StreamInfo;
 use crate::image_processing::convert_video_frame;
 use crate::video_frame::frame_pool::FramePool;
 use crate::video_frame::frame_pool::PooledVideoFrame;
-#[cfg(feature = "vaapi")]
+#[cfg(feature = "gbm")]
 use crate::video_frame::gbm_video_frame::{GbmDevice, GbmUsage, GbmVideoFrame};
 #[cfg(feature = "v4l2")]
 use crate::video_frame::v4l2_mmap_video_frame::V4l2MmapVideoFrame;
@@ -62,7 +62,7 @@ pub trait C2DecoderBackend {
     ) -> Result<DynStatelessVideoDecoder<V>, String>;
 }
 
-#[cfg(feature = "vaapi")]
+#[cfg(feature = "gbm")]
 type AuxiliaryVideoFrame = GbmVideoFrame;
 #[cfg(feature = "v4l2")]
 type AuxiliaryVideoFrame = V4l2MmapVideoFrame;
@@ -189,7 +189,7 @@ where
                 ),
             )
         } else {
-            #[cfg(feature = "vaapi")]
+            #[cfg(feature = "gbm")]
             {
                 let gbm_device = Arc::new(
                     GbmDevice::open(PathBuf::from("/dev/dri/renderD128"))

--- a/src/c2_wrapper/c2_encoder.rs
+++ b/src/c2_wrapper/c2_encoder.rs
@@ -250,6 +250,7 @@ where
                     timestamp: job.timestamp,
                     layout: Default::default(),
                     force_keyframe: false,
+                    force_idr: false,
                 };
                 #[cfg(feature = "vaapi")]
                 let encode_result = self.encoder.encode(meta, frame);

--- a/src/codec/h264/nalu_writer.rs
+++ b/src/codec/h264/nalu_writer.rs
@@ -177,13 +177,19 @@ impl<W: Write> NaluWriter<W> {
     /// Writes a H.264 NALU header.
     pub fn write_header(&mut self, idc: u8, _type: u8) -> NaluWriterResult<()> {
         self.0.flush()?;
-        self.0.inner_mut().write_header(idc, _type)?;
+        let _num_bytes = self.0.inner_mut().write_header(idc, _type)?;
+        // self.0.bits_written += num_bytes * 8;
         Ok(())
     }
 
     /// Returns `true` if next bits will be aligned to 8
     pub fn aligned(&self) -> bool {
         !self.0.has_data_pending()
+    }
+
+    /// Returns the number of trailing bits in the last byte.
+    pub fn flush(&mut self) -> NaluWriterResult<u8> {
+        Ok(self.0.flush()?)
     }
 }
 

--- a/src/codec/h264/synthesizer.rs
+++ b/src/codec/h264/synthesizer.rs
@@ -9,11 +9,16 @@ use crate::codec::h264::nalu_writer::NaluWriterError;
 use crate::codec::h264::parser::HrdParams;
 use crate::codec::h264::parser::NaluType;
 use crate::codec::h264::parser::Pps;
+use crate::codec::h264::parser::SliceHeader;
+#[cfg(feature = "vaapi")]
+use crate::codec::h264::parser::SliceType;
 use crate::codec::h264::parser::Sps;
 use crate::codec::h264::parser::DEFAULT_4X4_INTER;
 use crate::codec::h264::parser::DEFAULT_4X4_INTRA;
 use crate::codec::h264::parser::DEFAULT_8X8_INTER;
 use crate::codec::h264::parser::DEFAULT_8X8_INTRA;
+#[cfg(feature = "vaapi")]
+use crate::encoder::stateless::h264::IsReference;
 
 mod private {
     pub trait NaluStruct {}
@@ -22,6 +27,8 @@ mod private {
 impl private::NaluStruct for Sps {}
 
 impl private::NaluStruct for Pps {}
+
+impl private::NaluStruct for SliceHeader {}
 
 #[derive(Debug)]
 pub enum SynthesizerError {
@@ -440,6 +447,291 @@ impl<'n, W: Write> Synthesizer<'n, Pps, W> {
         }
 
         self.se(self.nalu.second_chroma_qp_index_offset)?;
+
+        Ok(())
+    }
+}
+
+#[cfg(feature = "vaapi")]
+pub type NumTrailingBits = u8;
+
+#[cfg(feature = "vaapi")]
+impl<'n, W: Write> Synthesizer<'n, SliceHeader, W> {
+    pub fn synthesize(
+        header: &'n SliceHeader,
+        sps: &'n Sps,
+        pps: &'n Pps,
+        is_idr: bool,
+        is_ref: IsReference,
+        writer: W,
+        ep_enabled: bool,
+    ) -> SynthesizerResult<NumTrailingBits> {
+        let mut s = Self { writer: NaluWriter::<W>::new(writer, ep_enabled), nalu: header };
+
+        let ref_idc = if is_idr {
+            3
+        } else if is_ref == IsReference::LongTerm {
+            2
+        } else if is_ref == IsReference::ShortTerm {
+            1
+        } else {
+            0
+        };
+        let nalu_type = if is_idr { NaluType::SliceIdr } else { NaluType::Slice };
+        s.writer.write_header(ref_idc, nalu_type as u8)?;
+        s.slice_header_data(sps, pps, is_idr, is_ref)?;
+        let num_trailing_bits = s.writer.flush()?;
+        Ok(num_trailing_bits)
+    }
+
+    fn slice_header_data(
+        &mut self,
+        sps: &Sps,
+        pps: &Pps,
+        is_idr: bool,
+        is_ref: IsReference,
+    ) -> SynthesizerResult<()> {
+        let hdr = self.nalu;
+
+        self.ue(hdr.first_mb_in_slice)?;
+        self.ue(hdr.slice_type as u32)?;
+        self.ue(hdr.pic_parameter_set_id)?;
+
+        if sps.separate_colour_plane_flag {
+            self.u(2, hdr.colour_plane_id)?;
+        }
+
+        let frame_num_bits = sps.log2_max_frame_num_minus4 as usize + 4;
+        self.u(frame_num_bits, hdr.frame_num)?;
+
+        if !sps.frame_mbs_only_flag {
+            self.u(1, hdr.field_pic_flag as u32)?;
+            if hdr.field_pic_flag {
+                self.u(1, hdr.bottom_field_flag as u32)?;
+            }
+        }
+
+        if is_idr {
+            self.ue(hdr.idr_pic_id)?;
+        }
+
+        if sps.pic_order_cnt_type == 0 {
+            let pic_order_cnt_lsb_bits = sps.log2_max_pic_order_cnt_lsb_minus4 as usize + 4;
+            self.u(pic_order_cnt_lsb_bits, hdr.pic_order_cnt_lsb)?;
+            if pps.bottom_field_pic_order_in_frame_present_flag && !hdr.field_pic_flag {
+                self.se(hdr.delta_pic_order_cnt_bottom)?;
+            }
+        }
+
+        if sps.pic_order_cnt_type == 1 && !sps.delta_pic_order_always_zero_flag {
+            self.se(hdr.delta_pic_order_cnt[0])?;
+            if pps.bottom_field_pic_order_in_frame_present_flag && !hdr.field_pic_flag {
+                self.se(hdr.delta_pic_order_cnt[1])?;
+            }
+        }
+
+        if pps.redundant_pic_cnt_present_flag {
+            self.ue(hdr.redundant_pic_cnt)?;
+        }
+
+        if hdr.slice_type == SliceType::B {
+            self.u(1, hdr.direct_spatial_mv_pred_flag as u32)?;
+        }
+
+        if hdr.slice_type == SliceType::P
+            || hdr.slice_type == SliceType::Sp
+            || hdr.slice_type == SliceType::B
+        {
+            self.u(1, hdr.num_ref_idx_active_override_flag as u32)?;
+            if hdr.num_ref_idx_active_override_flag {
+                self.ue(hdr.num_ref_idx_l0_active_minus1)?;
+                if hdr.slice_type == SliceType::B {
+                    self.ue(hdr.num_ref_idx_l1_active_minus1)?;
+                }
+            }
+        }
+
+        self.ref_pic_list_modification(hdr)?;
+
+        if (pps.weighted_pred_flag
+            && (hdr.slice_type == SliceType::P || hdr.slice_type == SliceType::Sp))
+            || (pps.weighted_bipred_idc == 1 && hdr.slice_type == SliceType::B)
+        {
+            self.pred_weight_table(hdr, sps)?;
+        }
+
+        if is_ref != IsReference::No {
+            self.dec_ref_pic_marking(hdr, is_idr)?;
+        }
+
+        if pps.entropy_coding_mode_flag
+            && hdr.slice_type != SliceType::I
+            && hdr.slice_type != SliceType::Si
+        {
+            self.ue(hdr.cabac_init_idc)?;
+        }
+
+        self.se(hdr.slice_qp_delta)?;
+
+        if hdr.slice_type == SliceType::Sp || hdr.slice_type == SliceType::Si {
+            if hdr.slice_type == SliceType::Sp {
+                self.u(1, hdr.sp_for_switch_flag as u32)?;
+            }
+            self.se(hdr.slice_qs_delta)?;
+        }
+
+        if pps.deblocking_filter_control_present_flag {
+            self.ue(hdr.disable_deblocking_filter_idc)?;
+            if hdr.disable_deblocking_filter_idc != 1 {
+                self.se(hdr.slice_alpha_c0_offset_div2)?;
+                self.se(hdr.slice_beta_offset_div2)?;
+            }
+        }
+
+        if pps.num_slice_groups_minus1 > 0 {
+            // Slice groups are not supported, this should have been caught earlier
+            return Err(SynthesizerError::Unsupported);
+        }
+
+        Ok(())
+    }
+
+    fn ref_pic_list_modification(&mut self, hdr: &SliceHeader) -> SynthesizerResult<()> {
+        let slice_type_mod5 = hdr.slice_type as u8 % 5;
+
+        if slice_type_mod5 != 2 && slice_type_mod5 != 4 {
+            self.u(1, hdr.ref_pic_list_modification_flag_l0 as u32)?;
+            if hdr.ref_pic_list_modification_flag_l0 {
+                for modification in &hdr.ref_pic_list_modification_l0 {
+                    self.ue(modification.modification_of_pic_nums_idc)?;
+                    if modification.modification_of_pic_nums_idc == 0
+                        || modification.modification_of_pic_nums_idc == 1
+                    {
+                        self.ue(modification.abs_diff_pic_num_minus1)?;
+                    } else if modification.modification_of_pic_nums_idc == 2 {
+                        self.ue(modification.long_term_pic_num)?;
+                    }
+                }
+                self.ue(3u32)?;
+            }
+        }
+
+        if slice_type_mod5 == 1 {
+            self.u(1, hdr.ref_pic_list_modification_flag_l1 as u32)?;
+            if hdr.ref_pic_list_modification_flag_l1 {
+                for modification in &hdr.ref_pic_list_modification_l1 {
+                    self.ue(modification.modification_of_pic_nums_idc)?;
+                    if modification.modification_of_pic_nums_idc == 0
+                        || modification.modification_of_pic_nums_idc == 1
+                    {
+                        self.ue(modification.abs_diff_pic_num_minus1)?;
+                    } else if modification.modification_of_pic_nums_idc == 2 {
+                        self.ue(modification.long_term_pic_num)?;
+                    }
+                }
+                self.ue(3u32)?;
+            }
+        }
+
+        Ok(())
+    }
+
+    fn pred_weight_table(&mut self, hdr: &SliceHeader, sps: &Sps) -> SynthesizerResult<()> {
+        let pwt = &hdr.pred_weight_table;
+        let chroma_array_type = sps.chroma_array_type();
+
+        self.ue(pwt.luma_log2_weight_denom)?;
+        if chroma_array_type != 0 {
+            self.ue(pwt.chroma_log2_weight_denom)?;
+        }
+
+        let num_ref_idx_l0 = (hdr.num_ref_idx_l0_active_minus1 + 1) as usize;
+        for i in 0..num_ref_idx_l0 {
+            let luma_weight_l0_flag = pwt.luma_weight_l0[i] != (1 << pwt.luma_log2_weight_denom);
+            self.u(1, luma_weight_l0_flag as u32)?;
+            if luma_weight_l0_flag {
+                self.se(pwt.luma_weight_l0[i])?;
+                self.se(pwt.luma_offset_l0[i])?;
+            }
+
+            if chroma_array_type != 0 {
+                let default_weight = 1 << pwt.chroma_log2_weight_denom;
+                let chroma_weight_l0_flag = pwt.chroma_weight_l0[i][0] != default_weight
+                    || pwt.chroma_weight_l0[i][1] != default_weight
+                    || pwt.chroma_offset_l0[i][0] != 0
+                    || pwt.chroma_offset_l0[i][1] != 0;
+                self.u(1, chroma_weight_l0_flag as u32)?;
+                if chroma_weight_l0_flag {
+                    for j in 0..2 {
+                        self.se(pwt.chroma_weight_l0[i][j])?;
+                        self.se(pwt.chroma_offset_l0[i][j])?;
+                    }
+                }
+            }
+        }
+
+        if hdr.slice_type as u8 % 5 == 1 {
+            let num_ref_idx_l1 = (hdr.num_ref_idx_l1_active_minus1 + 1) as usize;
+            for i in 0..num_ref_idx_l1 {
+                let luma_weight_l1_flag =
+                    pwt.luma_weight_l1[i] != (1 << pwt.luma_log2_weight_denom) as i16;
+                self.u(1, luma_weight_l1_flag as u32)?;
+                if luma_weight_l1_flag {
+                    self.se(pwt.luma_weight_l1[i])?;
+                    self.se(pwt.luma_offset_l1[i])?;
+                }
+
+                if chroma_array_type != 0 {
+                    let default_weight = (1 << pwt.chroma_log2_weight_denom) as i16;
+                    let chroma_weight_l1_flag = pwt.chroma_weight_l1[i][0] != default_weight
+                        || pwt.chroma_weight_l1[i][1] != default_weight
+                        || pwt.chroma_offset_l1[i][0] != 0
+                        || pwt.chroma_offset_l1[i][1] != 0;
+                    self.u(1, chroma_weight_l1_flag as u32)?;
+                    if chroma_weight_l1_flag {
+                        for j in 0..2 {
+                            self.se(pwt.chroma_weight_l1[i][j])?;
+                            self.se(pwt.chroma_offset_l1[i][j])?;
+                        }
+                    }
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    fn dec_ref_pic_marking(&mut self, hdr: &SliceHeader, is_idr: bool) -> SynthesizerResult<()> {
+        let rpm = &hdr.dec_ref_pic_marking;
+
+        if is_idr {
+            self.u(1, rpm.no_output_of_prior_pics_flag as u32)?;
+            self.u(1, rpm.long_term_reference_flag as u32)?;
+        } else {
+            self.u(1, rpm.adaptive_ref_pic_marking_mode_flag as u32)?;
+            if rpm.adaptive_ref_pic_marking_mode_flag {
+                for marking in &rpm.inner {
+                    self.ue(marking.memory_management_control_operation)?;
+                    if marking.memory_management_control_operation == 1
+                        || marking.memory_management_control_operation == 3
+                    {
+                        self.ue(marking.difference_of_pic_nums_minus1)?;
+                    }
+                    if marking.memory_management_control_operation == 2 {
+                        self.ue(marking.long_term_pic_num)?;
+                    }
+                    if marking.memory_management_control_operation == 3
+                        || marking.memory_management_control_operation == 6
+                    {
+                        self.ue(marking.long_term_frame_idx)?;
+                    }
+                    if marking.memory_management_control_operation == 4 {
+                        self.ue(marking.max_long_term_frame_idx.to_value_plus1())?;
+                    }
+                }
+                self.ue(0u32)?;
+            }
+        }
 
         Ok(())
     }

--- a/src/decoder/stateless.rs
+++ b/src/decoder/stateless.rs
@@ -11,8 +11,10 @@
 //! combining a codec codec to a [backend](crate::backend), after which bitstream units can be
 //! submitted through the [`StatelessDecoder::decode`] method.
 
+#[cfg(feature = "av1")]
 pub mod av1;
 pub mod h264;
+#[cfg(feature = "h265")]
 pub mod h265;
 pub mod vp8;
 pub mod vp9;

--- a/src/decoder/stateless/h264/vaapi.rs
+++ b/src/decoder/stateless/h264/vaapi.rs
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 use std::rc::Rc;
+use std::sync::Arc;
 
 use anyhow::anyhow;
 use anyhow::Context as AnyhowContext;
@@ -546,7 +547,7 @@ impl<V: VideoFrame> StatelessH264DecoderBackend for VaapiBackend<V> {
 impl<V: VideoFrame> StatelessDecoder<H264, VaapiBackend<V>> {
     // Creates a new instance of the decoder using the VAAPI backend.
     pub fn new_vaapi(
-        display: Rc<Display>,
+        display: Arc<Display>,
         blocking_mode: BlockingMode,
     ) -> Result<Self, NewStatelessDecoderError> {
         Self::new(VaapiBackend::new(display, false), blocking_mode)

--- a/src/decoder/stateless/vp8/vaapi.rs
+++ b/src/decoder/stateless/vp8/vaapi.rs
@@ -4,6 +4,7 @@
 
 use std::convert::TryFrom;
 use std::rc::Rc;
+use std::sync::Arc;
 
 use anyhow::anyhow;
 use anyhow::Context;
@@ -290,7 +291,7 @@ impl<V: VideoFrame> StatelessVp8DecoderBackend for VaapiBackend<V> {
 impl<V: VideoFrame> StatelessDecoder<Vp8, VaapiBackend<V>> {
     // Creates a new instance of the decoder using the VAAPI backend.
     pub fn new_vaapi(
-        display: Rc<Display>,
+        display: Arc<Display>,
         blocking_mode: BlockingMode,
     ) -> Result<Self, NewStatelessDecoderError> {
         Self::new(VaapiBackend::new(display, false), blocking_mode)

--- a/src/decoder/stateless/vp9/vaapi.rs
+++ b/src/decoder/stateless/vp9/vaapi.rs
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 use std::rc::Rc;
+use std::sync::Arc;
 
 use anyhow::anyhow;
 use anyhow::Context;
@@ -290,7 +291,7 @@ impl<V: VideoFrame> StatelessVp9DecoderBackend for VaapiBackend<V> {
 impl<V: VideoFrame> StatelessDecoder<Vp9, VaapiBackend<V>> {
     // Creates a new instance of the decoder using the VAAPI backend.
     pub fn new_vaapi(
-        display: Rc<Display>,
+        display: Arc<Display>,
         blocking_mode: BlockingMode,
     ) -> Result<Self, NewStatelessDecoderError> {
         Self::new(VaapiBackend::new(display, true), blocking_mode)

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -28,6 +28,9 @@ pub enum RateControl {
     /// The encoder shall maintain the constant bitrate
     ConstantBitrate(u64),
 
+    /// The encoder shall target a bitrate value, but it may vary until the maximum bitrate
+    VariableBitrate { target: u64, maximum: u64 },
+
     /// The encoder shall maintain codec specific quality parameter constant (eg. QP for H.264)
     /// disregarding bitrate.
     ConstantQuality(u32),
@@ -42,6 +45,15 @@ impl RateControl {
     pub(crate) fn bitrate_target(&self) -> Option<u64> {
         match self {
             RateControl::ConstantBitrate(target) => Some(*target),
+            RateControl::VariableBitrate { target, .. } => Some(*target),
+            RateControl::ConstantQuality(_) => None,
+        }
+    }
+
+    pub(crate) fn bitrate_maximum(&self) -> Option<u64> {
+        match self {
+            RateControl::ConstantBitrate(bitrate) => Some(*bitrate),
+            RateControl::VariableBitrate { maximum, .. } => Some(*maximum),
             RateControl::ConstantQuality(_) => None,
         }
     }

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -4,8 +4,10 @@
 
 use std::fmt;
 
+#[cfg(feature = "av1")]
 pub mod av1;
 pub mod h264;
+#[cfg(feature = "h265")]
 pub mod h265;
 pub mod vp8;
 pub mod vp9;
@@ -13,6 +15,7 @@ pub mod vp9;
 pub mod stateful;
 pub mod stateless;
 
+#[cfg(feature = "av1")]
 use crate::codec::av1::synthesizer::SynthesizerError as AV1SynthesizerError;
 use crate::codec::h264::synthesizer::SynthesizerError as H264SynthesizerError;
 use crate::encoder::stateful::StatefulBackendError;
@@ -113,6 +116,7 @@ pub enum EncodeError {
     StatelessBackendError(StatelessBackendError),
     StatefulBackendError(StatefulBackendError),
     H264SynthesizerError(H264SynthesizerError),
+    #[cfg(feature = "av1")]
     AV1SynthesizerError(AV1SynthesizerError),
 }
 
@@ -126,6 +130,7 @@ impl fmt::Display for EncodeError {
             EncodeError::StatelessBackendError(x) => write!(f, "{}", x.to_string()),
             EncodeError::StatefulBackendError(x) => write!(f, "{}", x.to_string()),
             EncodeError::H264SynthesizerError(x) => write!(f, "{}", x.to_string()),
+            #[cfg(feature = "av1")]
             EncodeError::AV1SynthesizerError(x) => write!(f, "{}", x.to_string()),
         }
     }
@@ -149,6 +154,7 @@ impl From<H264SynthesizerError> for EncodeError {
     }
 }
 
+#[cfg(feature = "av1")]
 impl From<AV1SynthesizerError> for EncodeError {
     fn from(err: AV1SynthesizerError) -> Self {
         EncodeError::AV1SynthesizerError(err)

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -79,6 +79,10 @@ pub struct Tunings {
     pub min_quality: u32,
     /// Maximum value of codec specific quality parameter constant (eg. QP for H.264)
     pub max_quality: u32,
+    /// Buffer size, in bits, used for rate control
+    pub rc_buffer_size: Option<u32>,
+    /// Maximum frame size, in bits
+    pub max_frame_size: Option<u32>,
 }
 
 impl Default for Tunings {
@@ -88,6 +92,8 @@ impl Default for Tunings {
             framerate: 30,
             min_quality: 0,
             max_quality: u32::MAX,
+            rc_buffer_size: None,
+            max_frame_size: None,
         }
     }
 }

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -83,6 +83,8 @@ pub struct Tunings {
     pub rc_buffer_size: Option<u32>,
     /// Maximum frame size, in bits
     pub max_frame_size: Option<u32>,
+    /// Codec and implementation defined quality
+    pub quality: Option<u32>,
 }
 
 impl Default for Tunings {
@@ -94,6 +96,7 @@ impl Default for Tunings {
             max_quality: u32::MAX,
             rc_buffer_size: None,
             max_frame_size: None,
+            quality: None,
         }
     }
 }

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -86,6 +86,7 @@ pub struct FrameMetadata {
     pub timestamp: u64,
     pub layout: FrameLayout,
     pub force_keyframe: bool,
+    pub force_idr: bool,
 }
 
 /// Encoder's coded output with contained frame.
@@ -415,8 +416,12 @@ pub(crate) mod tests {
                 panic!("Unrecognized frame layout used during test");
             }
 
-            let meta =
-                FrameMetadata { timestamp, layout: frame.layout.clone(), force_keyframe: false };
+            let meta = FrameMetadata {
+                timestamp,
+                layout: frame.layout.clone(),
+                force_keyframe: false,
+                force_idr: false,
+            };
 
             (meta, frame)
         })

--- a/src/encoder/stateless.rs
+++ b/src/encoder/stateless.rs
@@ -14,7 +14,7 @@ use crate::encoder::Tunings;
 use crate::encoder::VideoEncoder;
 use crate::BlockingMode;
 
-#[cfg(feature = "vaapi")]
+#[cfg(all(feature = "vaapi", feature = "av1"))]
 pub mod av1;
 #[cfg(feature = "vaapi")]
 pub mod h264;

--- a/src/encoder/stateless/av1/vaapi.rs
+++ b/src/encoder/stateless/av1/vaapi.rs
@@ -675,8 +675,12 @@ mod tests {
 
         upload_test_frame_nv12(&display, &surface, 0.0);
 
-        let input_meta =
-            FrameMetadata { layout: frame_layout, force_keyframe: false, timestamp: 0 };
+        let input_meta = FrameMetadata {
+            layout: frame_layout,
+            force_keyframe: false,
+            timestamp: 0,
+            force_idr: false,
+        };
 
         let input = backend.import_picture(&input_meta, surface).unwrap();
 

--- a/src/encoder/stateless/h264/predictor.rs
+++ b/src/encoder/stateless/h264/predictor.rs
@@ -263,7 +263,6 @@ impl<Picture, Reference>
     }
 
     fn apply_tunings(&mut self, _tunings: &Tunings) -> EncodeResult<()> {
-        self.new_sequence();
         Ok(())
     }
 }

--- a/src/encoder/stateless/h264/vaapi.rs
+++ b/src/encoder/stateless/h264/vaapi.rs
@@ -433,6 +433,18 @@ where
             }
         }
 
+        if let Some(quality) = request.tunings.quality {
+            if self.supports_quality_range(quality)? {
+                let quality_param =
+                    BufferType::EncMiscParameter(libva::EncMiscParameter::QualityLevel(
+                        libva::EncMiscParameterBufferQualityLevel::new(quality),
+                    ));
+                picture.add_buffer(self.context().create_buffer(quality_param)?);
+            } else {
+                warn!("Quality level not supported");
+            }
+        }
+
         // Start processing the picture encoding
         let picture = picture.begin().context("picture begin")?;
         let picture = picture.render().context("picture render")?;

--- a/src/encoder/stateless/h264/vaapi.rs
+++ b/src/encoder/stateless/h264/vaapi.rs
@@ -5,6 +5,7 @@
 use std::any::Any;
 use std::borrow::Borrow;
 use std::rc::Rc;
+use std::sync::Arc;
 
 use anyhow::Context;
 use libva::BufferType;
@@ -433,7 +434,7 @@ where
 
 impl<V: VideoFrame> StatelessEncoder<V, VaapiBackend<V::MemDescriptor, Surface<V::MemDescriptor>>> {
     pub fn new_vaapi(
-        display: Rc<Display>,
+        display: Arc<Display>,
         config: EncoderConfig,
         fourcc: Fourcc,
         coded_size: Resolution,

--- a/src/encoder/stateless/h264/vaapi.rs
+++ b/src/encoder/stateless/h264/vaapi.rs
@@ -450,6 +450,7 @@ impl<V: VideoFrame> StatelessEncoder<V, VaapiBackend<V::MemDescriptor, Surface<V
 
         let bitrate_control = match config.initial_tunings.rate_control {
             RateControl::ConstantBitrate(_) => libva::VA_RC_CBR,
+            RateControl::VariableBitrate { .. } => libva::VA_RC_VBR,
             RateControl::ConstantQuality(_) => libva::VA_RC_CQP,
         };
 

--- a/src/encoder/stateless/h264/vaapi.rs
+++ b/src/encoder/stateless/h264/vaapi.rs
@@ -543,8 +543,12 @@ pub(super) mod tests {
 
         upload_test_frame_nv12(&display, &surface, 0.0);
 
-        let input_meta =
-            FrameMetadata { layout: frame_layout, force_keyframe: false, timestamp: 0 };
+        let input_meta = FrameMetadata {
+            layout: frame_layout,
+            force_keyframe: false,
+            timestamp: 0,
+            force_idr: false,
+        };
 
         let pic = backend.import_picture(&input_meta, surface).unwrap();
 

--- a/src/encoder/stateless/h264/vaapi.rs
+++ b/src/encoder/stateless/h264/vaapi.rs
@@ -29,6 +29,7 @@ use libva::VAProfile;
 use libva::VA_INVALID_ID;
 use libva::VA_PICTURE_H264_LONG_TERM_REFERENCE;
 use libva::VA_PICTURE_H264_SHORT_TERM_REFERENCE;
+use log::warn;
 
 use crate::backend::vaapi::encoder::tunings_to_libva_rc;
 use crate::backend::vaapi::encoder::CodedOutputPromise;
@@ -409,6 +410,28 @@ where
         picture.add_buffer(self.context().create_buffer(slice_param)?);
         picture.add_buffer(self.context().create_buffer(rc_param)?);
         picture.add_buffer(self.context().create_buffer(framerate_param)?);
+
+        if let Some(rc_buffer_size) = request.tunings.rc_buffer_size {
+            let hrd_buffer_size = rc_buffer_size as u32;
+            let hrd_buffer_fullness = hrd_buffer_size * 3 / 4;
+
+            let hrd_param = BufferType::EncMiscParameter(libva::EncMiscParameter::HRD(
+                libva::EncMiscParameterHRD::new(hrd_buffer_size, hrd_buffer_fullness),
+            ));
+            picture.add_buffer(self.context().create_buffer(hrd_param)?);
+        }
+
+        if let Some(max_frame_size) = request.tunings.max_frame_size {
+            if self.supports_max_frame_size()? {
+                let max_frame_size_param =
+                    BufferType::EncMiscParameter(libva::EncMiscParameter::MaxFrameSize(
+                        libva::EncMiscParameterBufferMaxFrameSize::new(max_frame_size as u32),
+                    ));
+                picture.add_buffer(self.context().create_buffer(max_frame_size_param)?);
+            } else {
+                warn!("Max frame size not supported");
+            }
+        }
 
         // Start processing the picture encoding
         let picture = picture.begin().context("picture begin")?;

--- a/src/encoder/stateless/h264/vaapi.rs
+++ b/src/encoder/stateless/h264/vaapi.rs
@@ -484,6 +484,37 @@ impl<V: VideoFrame> StatelessEncoder<V, VaapiBackend<V::MemDescriptor, Surface<V
     }
 }
 
+impl<D: SurfaceMemoryDescriptor, S: std::borrow::Borrow<Surface<D>> + 'static>
+    StatelessEncoder<S, VaapiBackend<D, S>>
+{
+    pub fn new_native_vaapi(
+        display: Arc<Display>,
+        config: EncoderConfig,
+        fourcc: Fourcc,
+        coded_size: Resolution,
+        low_power: bool,
+        blocking_mode: BlockingMode,
+    ) -> EncodeResult<Self> {
+        let va_profile = match config.profile {
+            Profile::Baseline => VAProfile::VAProfileH264ConstrainedBaseline,
+            Profile::Main => VAProfile::VAProfileH264Main,
+            Profile::High => VAProfile::VAProfileH264High,
+            _ => return Err(StatelessBackendError::UnsupportedProfile.into()),
+        };
+
+        let bitrate_control = match config.initial_tunings.rate_control {
+            RateControl::ConstantBitrate(_) => libva::VA_RC_CBR,
+            RateControl::VariableBitrate { .. } => libva::VA_RC_VBR,
+            RateControl::ConstantQuality(_) => libva::VA_RC_CQP,
+        };
+
+        let backend =
+            VaapiBackend::new(display, va_profile, fourcc, coded_size, bitrate_control, low_power)?;
+
+        Self::new_h264(backend, config, blocking_mode)
+    }
+}
+
 #[cfg(test)]
 pub(super) mod tests {
     use libva::Display;
@@ -685,7 +716,7 @@ pub(super) mod tests {
             ],
         };
 
-        let mut encoder = VaapiH264Encoder::new_vaapi(
+        let mut encoder = VaapiH264Encoder::new_native_vaapi(
             Rc::clone(&display),
             config,
             frame_layout.format.0,

--- a/src/encoder/stateless/h264/vaapi.rs
+++ b/src/encoder/stateless/h264/vaapi.rs
@@ -11,6 +11,8 @@ use anyhow::Context;
 use libva::BufferType;
 use libva::Display;
 use libva::EncCodedBuffer;
+use libva::EncPackedHeaderParameter;
+use libva::EncPackedHeaderType;
 use libva::EncPictureParameter;
 use libva::EncPictureParameterBufferH264;
 use libva::EncSequenceParameter;
@@ -39,6 +41,8 @@ use crate::codec::h264::parser::Pps;
 use crate::codec::h264::parser::Profile;
 use crate::codec::h264::parser::SliceHeader;
 use crate::codec::h264::parser::Sps;
+use crate::codec::h264::synthesizer::Synthesizer;
+use crate::codec::h264::synthesizer::SynthesizerResult;
 use crate::encoder::h264::EncoderConfig;
 use crate::encoder::h264::H264;
 use crate::encoder::stateless::h264::predictor::MAX_QP;
@@ -347,6 +351,42 @@ where
             header.slice_beta_offset_div2,
         )))
     }
+
+    fn build_enc_packed_slice_param_and_data(
+        request: &Request<'_, H>,
+    ) -> SynthesizerResult<(BufferType, BufferType)> {
+        const ENABLE_EMULATION_PREVENTION: bool = false;
+        let (buffer, length_in_bits) =
+            Self::build_slice_header(request, ENABLE_EMULATION_PREVENTION)?;
+        let packed_slice_param =
+            BufferType::EncPackedHeaderParameter(EncPackedHeaderParameter::new(
+                EncPackedHeaderType::Slice,
+                length_in_bits as u32,
+                ENABLE_EMULATION_PREVENTION,
+            ));
+        let packed_slice_data = BufferType::EncPackedHeaderData(buffer);
+        Ok((packed_slice_param, packed_slice_data))
+    }
+
+    fn build_slice_header(
+        request: &Request<'_, H>,
+        ep_enabled: bool,
+    ) -> SynthesizerResult<(Vec<u8>, usize)> {
+        let mut buffer = Vec::new();
+
+        let num_trailing_bits = Synthesizer::<SliceHeader, _>::synthesize(
+            &request.header,
+            &request.sps,
+            &request.pps,
+            request.is_idr,
+            request.dpb_meta.is_reference,
+            &mut buffer,
+            ep_enabled,
+        )?;
+
+        let length_in_bits = buffer.len() * 8 - num_trailing_bits as usize;
+        Ok((buffer, length_in_bits))
+    }
 }
 
 impl<M, H> StatelessH264EncoderBackend for VaapiBackend<M, H>
@@ -388,6 +428,17 @@ where
             .map(|entry| entry as Rc<dyn Any>)
             .collect();
 
+        let packed_slice_header_buffers = if self
+            .supports_packed_header(libva::VA_ENC_PACKED_HEADER_SLICE)?
+        {
+            Some(
+                Self::build_enc_packed_slice_param_and_data(&request)
+                    .map_err(|e| anyhow::anyhow!("Failed to build packed slice header: {}", e))?,
+            )
+        } else {
+            None
+        };
+
         // Clone picture using [`Picture::new_from_same_surface`] to avoid
         // creatig a shared cell picture between its references and processed
         // picture.
@@ -408,6 +459,12 @@ where
         picture.add_buffer(self.context().create_buffer(seq_param)?);
         picture.add_buffer(self.context().create_buffer(pic_param)?);
         picture.add_buffer(self.context().create_buffer(slice_param)?);
+
+        if let Some((packed_slice_param, packed_slice_data)) = packed_slice_header_buffers {
+            picture.add_buffer(self.context().create_buffer(packed_slice_param)?);
+            picture.add_buffer(self.context().create_buffer(packed_slice_data)?);
+        }
+
         picture.add_buffer(self.context().create_buffer(rc_param)?);
         picture.add_buffer(self.context().create_buffer(framerate_param)?);
 
@@ -450,18 +507,12 @@ where
         let picture = picture.render().context("picture render")?;
         let picture = picture.end().context("picture end")?;
 
-        // HACK: Make sure that slice nalu start code is at least 4 bytes.
-        // TODO: Use packed headers to supply slice header with nalu start code of size 4 and get
-        // rid of this hack.
-        let mut coded_output = request.coded_output;
-        coded_output.push(0);
-
         // libva will handle the synchronization of reconstructed surface with implicit fences.
         // Therefore return the reconstructed frame immediately.
         let reference_promise = ReadyPromise::from(recon);
 
         let bitstream_promise =
-            CodedOutputPromise::new(picture, references, coded_buf, coded_output);
+            CodedOutputPromise::new(picture, references, coded_buf, request.coded_output);
 
         Ok((reference_promise, bitstream_promise))
     }

--- a/src/encoder/stateless/predictor.rs
+++ b/src/encoder/stateless/predictor.rs
@@ -97,12 +97,47 @@ where
         Ok(())
     }
 
+    fn adjust_tunings_for_wrap(&mut self, old_counter: usize) {
+        if old_counter == 0 {
+            return;
+        }
+
+        for (when_counter, _) in self.tunings_queue.iter_mut() {
+            if *when_counter >= old_counter {
+                *when_counter -= old_counter;
+            } else {
+                *when_counter = 0;
+            }
+        }
+    }
+
+    fn increment_counter(&mut self) {
+        let old_counter = self.counter;
+        self.counter = self.counter.wrapping_add(1) % (self.limit as usize);
+
+        if self.counter == 0 && old_counter != 0 {
+            // Counter wrapped around naturally at the limit
+            self.adjust_tunings_for_wrap(old_counter);
+        }
+    }
+
     fn next_request(&mut self) -> EncodeResult<Vec<Request>> {
         log::trace!("Pending frames in the queue: {}", self.queue.len());
 
         let mut requests = Vec::new();
-        while let Some((input, meta)) = self.queue.pop_front() {
+        while let Some((input, mut meta)) = self.queue.pop_front() {
             self.pop_tunings()?;
+
+            if meta.force_idr {
+                self.adjust_tunings_for_wrap(self.counter);
+                self.counter = 0;
+                meta.force_keyframe = true;
+            }
+
+            if self.counter == 0 && !meta.force_idr {
+                // Natural IDR due to limit wrap - ensure metadata reflects this
+                meta.force_idr = true;
+            }
 
             if self.counter == 0 || meta.force_keyframe {
                 log::trace!("Requesting keyframe/IDR for timestamp={}", meta.timestamp);
@@ -114,7 +149,7 @@ where
                 let request = self.request_keyframe(input, meta, self.counter == 0)?;
 
                 requests.push(request);
-                self.counter = self.counter.wrapping_add(1) % (self.limit as usize);
+                self.increment_counter();
             } else if self.references.is_empty() {
                 log::trace!("Awaiting more reconstructed frames");
                 // There is no enough frames reconstructed
@@ -125,7 +160,7 @@ where
                 let request = self.request_interframe(input, meta)?;
 
                 requests.push(request);
-                self.counter = self.counter.wrapping_add(1) % (self.limit as usize);
+                self.increment_counter();
 
                 break;
             }
@@ -243,6 +278,7 @@ mod tests {
                 planes: vec![],
             },
             force_keyframe,
+            force_idr: false,
         }
     }
 

--- a/src/encoder/stateless/predictor.rs
+++ b/src/encoder/stateless/predictor.rs
@@ -89,7 +89,7 @@ where
 
             // SAFETY: checked in loop condition
             let (_, tunings) = self.tunings_queue.pop_front().unwrap();
-            log::info!("Applying tuning {tunings:?}");
+            log::debug!("Applying tuning {tunings:?}");
             self.apply_tunings(&tunings)?;
             self.tunings = tunings;
         }

--- a/src/encoder/stateless/vp9/vaapi.rs
+++ b/src/encoder/stateless/vp9/vaapi.rs
@@ -5,6 +5,7 @@
 use std::any::Any;
 use std::borrow::Borrow;
 use std::rc::Rc;
+use std::sync::Arc;
 
 use anyhow::Context;
 use libva::BufferType;
@@ -257,7 +258,7 @@ where
 
 impl<V: VideoFrame> StatelessEncoder<V, VaapiBackend<V::MemDescriptor, Surface<V::MemDescriptor>>> {
     pub fn new_vaapi(
-        display: Rc<Display>,
+        display: Arc<Display>,
         config: EncoderConfig,
         fourcc: Fourcc,
         coded_size: Resolution,

--- a/src/encoder/stateless/vp9/vaapi.rs
+++ b/src/encoder/stateless/vp9/vaapi.rs
@@ -364,8 +364,12 @@ pub(super) mod tests {
 
         upload_test_frame_nv12(&display, &surface, 0.0);
 
-        let input_meta =
-            FrameMetadata { layout: frame_layout, force_keyframe: false, timestamp: 0 };
+        let input_meta = FrameMetadata {
+            layout: frame_layout,
+            force_keyframe: false,
+            force_idr: false,
+            timestamp: 0,
+        };
 
         let pic = backend.import_picture(&input_meta, surface).unwrap();
 

--- a/src/encoder/stateless/vp9/vaapi.rs
+++ b/src/encoder/stateless/vp9/vaapi.rs
@@ -267,6 +267,7 @@ impl<V: VideoFrame> StatelessEncoder<V, VaapiBackend<V::MemDescriptor, Surface<V
     ) -> EncodeResult<Self> {
         let bitrate_control = match config.initial_tunings.rate_control {
             RateControl::ConstantBitrate(_) => libva::VA_RC_CBR,
+            RateControl::VariableBitrate { .. } => libva::VA_RC_VBR,
             RateControl::ConstantQuality(_) => libva::VA_RC_CQP,
         };
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,7 +25,7 @@ pub mod codec;
 
 #[cfg(feature = "backend")]
 pub mod backend;
-#[cfg(feature = "backend")]
+#[cfg(feature = "c2-wrapper")]
 pub mod c2_wrapper;
 #[cfg(feature = "backend")]
 pub mod decoder;
@@ -270,9 +270,11 @@ impl From<DecodedFormat> for Fourcc {
 #[derive(Debug, PartialEq, Eq, Copy, Clone)]
 pub enum EncodedFormat {
     H264,
+    #[cfg(feature = "h265")]
     H265,
     VP8,
     VP9,
+    #[cfg(feature = "av1")]
     AV1,
 }
 
@@ -282,9 +284,11 @@ impl FromStr for EncodedFormat {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
             "h264" | "H264" => Ok(EncodedFormat::H264),
+            #[cfg(feature = "h265")]
             "h265" | "H265" => Ok(EncodedFormat::H265),
             "vp8" | "VP8" => Ok(EncodedFormat::VP8),
             "vp9" | "VP9" => Ok(EncodedFormat::VP9),
+            #[cfg(feature = "av1")]
             "av1" | "AV1" => Ok(EncodedFormat::AV1),
             _ => Err("unrecognized input format. Valid values: h264, h265, vp8, vp9, av1"),
         }
@@ -295,9 +299,11 @@ impl From<Fourcc> for EncodedFormat {
     fn from(fourcc: Fourcc) -> EncodedFormat {
         match fourcc.to_string().as_str() {
             "H264" => EncodedFormat::H264,
+            #[cfg(feature = "h265")]
             "HEVC" => EncodedFormat::H265,
             "VP80" => EncodedFormat::VP8,
             "VP90" => EncodedFormat::VP9,
+            #[cfg(feature = "av1")]
             "AV1F" => EncodedFormat::AV1,
             _ => todo!("Fourcc {} not yet supported", fourcc),
         }
@@ -308,9 +314,11 @@ impl From<EncodedFormat> for Fourcc {
     fn from(format: EncodedFormat) -> Fourcc {
         match format {
             EncodedFormat::H264 => Fourcc::from(b"H264"),
+            #[cfg(feature = "h265")]
             EncodedFormat::H265 => Fourcc::from(b"HEVC"),
             EncodedFormat::VP8 => Fourcc::from(b"VP80"),
             EncodedFormat::VP9 => Fourcc::from(b"VP90"),
+            #[cfg(feature = "av1")]
             EncodedFormat::AV1 => Fourcc::from(b"AV1F"),
         }
     }

--- a/src/video_frame.rs
+++ b/src/video_frame.rs
@@ -16,7 +16,7 @@ use crate::Fourcc;
 use crate::Resolution;
 
 pub mod frame_pool;
-#[cfg(feature = "backend")]
+#[cfg(feature = "gbm")]
 pub mod gbm_video_frame;
 #[cfg(feature = "backend")]
 pub mod generic_dma_video_frame;

--- a/src/video_frame.rs
+++ b/src/video_frame.rs
@@ -4,9 +4,7 @@
 
 use std::cell::RefCell;
 use std::fmt::Debug;
-#[cfg(feature = "vaapi")]
-use std::rc::Rc;
-#[cfg(feature = "v4l2")]
+#[cfg(any(feature = "vaapi", feature = "v4l2"))]
 use std::sync::Arc;
 
 use crate::utils::align_up;
@@ -274,7 +272,7 @@ pub trait VideoFrame: Send + Sync + Sized + Debug + 'static {
     fn process_dqbuf(&mut self, device: Arc<Device>, format: &Format, buf: &V4l2Buffer);
 
     #[cfg(feature = "vaapi")]
-    fn to_native_handle(&self, display: &Rc<Display>) -> Result<Self::NativeHandle, String>;
+    fn to_native_handle(&self, display: &Arc<Display>) -> Result<Self::NativeHandle, String>;
 }
 
 // Rust has restrictions about implementing foreign types, so this is a stupid workaround to get

--- a/src/video_frame/frame_pool.rs
+++ b/src/video_frame/frame_pool.rs
@@ -3,8 +3,6 @@
 // found in the LICENSE file.
 
 use std::collections::VecDeque;
-#[cfg(feature = "vaapi")]
-use std::rc::Rc;
 use std::sync::Arc;
 use std::sync::Mutex;
 use std::sync::Weak;
@@ -74,7 +72,7 @@ impl<V: VideoFrame> VideoFrame for PooledVideoFrame<V> {
     }
 
     #[cfg(feature = "vaapi")]
-    fn to_native_handle(&self, display: &Rc<Display>) -> Result<Self::NativeHandle, String> {
+    fn to_native_handle(&self, display: &Arc<Display>) -> Result<Self::NativeHandle, String> {
         self.inner.as_ref().unwrap().to_native_handle(display)
     }
 }

--- a/src/video_frame/generic_dma_video_frame.rs
+++ b/src/video_frame/generic_dma_video_frame.rs
@@ -535,8 +535,7 @@ impl VideoFrame for GenericDmaVideoFrame {
                 Some(u32::from(self.layout.format.0)),
                 self.resolution().width,
                 self.resolution().height,
-                // TODO: Should we add USAGE_HINT_ENCODER support?
-                Some(UsageHint::USAGE_HINT_DECODER),
+                Some(UsageHint::USAGE_HINT_ENCODER),
                 vec![self.clone()],
             )
             .map_err(|_| "Error importing GenericDmaVideoFrame to VA-API".to_string())?;

--- a/src/video_frame/generic_dma_video_frame.rs
+++ b/src/video_frame/generic_dma_video_frame.rs
@@ -12,11 +12,9 @@ use std::iter::zip;
 use std::num::NonZeroUsize;
 use std::os::fd::{AsFd, AsRawFd, BorrowedFd, FromRawFd};
 use std::ptr::NonNull;
-#[cfg(feature = "vaapi")]
-use std::rc::Rc;
 use std::slice;
 use std::sync::atomic::{fence, Ordering};
-#[cfg(feature = "v4l2")]
+#[cfg(any(feature = "vaapi", feature = "v4l2"))]
 use std::sync::Arc;
 
 use crate::video_frame::{ReadMapping, VideoFrame, WriteMapping};
@@ -514,7 +512,7 @@ impl VideoFrame for GenericDmaVideoFrame {
     fn process_dqbuf(&mut self, _device: Arc<Device>, _format: &Format, _buf: &V4l2Buffer) {}
 
     #[cfg(feature = "vaapi")]
-    fn to_native_handle(&self, display: &Rc<Display>) -> Result<Self::NativeHandle, String> {
+    fn to_native_handle(&self, display: &Arc<Display>) -> Result<Self::NativeHandle, String> {
         if self.is_compressed() {
             return Err("Compressed buffer export to VA-API is not currently supported".to_string());
         }


### PR DESCRIPTION
1. [Disable h265, av1, gbm and c2-wrapper by default.](https://github.com/discord/cros-codecs/commit/9c41d87ac1e93b150d24b372e03cfd68edc98315):
- libva 1.10 has no support for AV1.
- Some h265 fields are missing in libva 1.10, plus there's no VAAPI
  H.265 encoder in cros-codecs yet anyways.
- cros-codecs actually uses minigbm (Mesa gbm doesn't support NV12), and we don't use it, so we can
  just disable it.
- c2-wrapper is only useful for Android
2. [Bump cros-libva to 0.0.13](https://github.com/discord/cros-codecs/commit/5413c6c281d99c758afd8a1ed4a9aeddc3286da4)
3. [Add FrameMetadata::force_idr](https://github.com/discord/cros-codecs/commit/1ebcc1470c3e9f1e9e26b5533edc82954e52de81)
4. [Use Arc\<Display\>](https://github.com/discord/cros-codecs/commit/d8a5489d08eee7b134831f20427f5a1680892bd8): related to https://github.com/chromeos/cros-libva/pull/31


5. [Add RateControl::VariableBitrate and implement it for VAAPI encoder](https://github.com/discord/cros-codecs/commit/d3a94fca595952413bbce02d22d6b6684f51f71f)

6. [vaapi: allow frame skip and disable bit stuffing](https://github.com/discord/cros-codecs/commit/9487d04d55e90401711d43c920c0bd818dc27496) 

7. [vaapi: add rc_buffer_size and max_frame_size to Tunings](https://github.com/discord/cros-codecs/commit/6a54a8a4eaa0e3d142dcadbb01e4a1d0584aaefd)

8. [vaapi: add new_native_vaapi constructor to H264 encoder](https://github.com/discord/cros-codecs/pull/1/commits/4a41071f4bf28de1d810a421d7d744e6b7bae5cb)

9. [encoder: downgrade log from info to debug](https://github.com/discord/cros-codecs/pull/1/commits/3d795fdea267e12c40de771fa4c59d4d075238e1)

10. [encoder: do not push new SPS/PPS when applying tunings](https://github.com/discord/cros-codecs/pull/1/commits/6079eab119cb248c4c642fae7331c0f3d81a1153)

11. [video_frame: use HINT_ENCODER when importing dmabuf into vaapi](https://github.com/discord/cros-codecs/pull/1/commits/c6986fee0e3e9345911ab78a98fab385c90d5e5d)

12. [vaapi: add quality tuning and use in h.264 encoder](https://github.com/discord/cros-codecs/pull/1/commits/c199d51fb1fdb6b58174edc847000520f16f45a0)

13. [vaapi: add packed slice header for h.264 encoder](https://github.com/discord/cros-codecs/pull/1/commits/6761a45293adc0c7a123f497c0aac9c700d47f5d)
