### PR TITLE
vaapi: fixes and improvements for H.264 encoding

### DIFF
--- a/src/codec/h264/parser.rs
+++ b/src/codec/h264/parser.rs
@@ -429,6 +429,11 @@ impl SliceHeaderBuilder {
         self
     }
 
+    pub fn frame_num(mut self, value: u16) -> Self {
+        self.0.frame_num = value;
+        self
+    }
+
     pub fn pic_order_cnt_lsb(mut self, value: u16) -> Self {
         self.0.pic_order_cnt_lsb = value;
         self

--- a/src/codec/h264/parser.rs
+++ b/src/codec/h264/parser.rs
@@ -1675,6 +1675,11 @@ impl PpsBuilder {
         self
     }
 
+    pub fn transform_8x8_mode_flag(mut self, value: bool) -> Self {
+        self.0.transform_8x8_mode_flag = value;
+        self
+    }
+
     pub fn deblocking_filter_control_present_flag(mut self, value: bool) -> Self {
         self.0.deblocking_filter_control_present_flag = value;
         self

--- a/src/codec/h264/parser.rs
+++ b/src/codec/h264/parser.rs
@@ -541,7 +541,7 @@ impl Default for SliceType {
     }
 }
 
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
 pub enum Profile {
     Baseline = 66,
@@ -1668,6 +1668,11 @@ impl PpsBuilder {
 
     pub fn pic_init_qp(self, value: u8) -> Self {
         self.pic_init_qp_minus26(value as i8 - 26)
+    }
+
+    pub fn entropy_coding_mode_flag(mut self, value: bool) -> Self {
+        self.0.entropy_coding_mode_flag = value;
+        self
     }
 
     pub fn deblocking_filter_control_present_flag(mut self, value: bool) -> Self {

--- a/src/encoder/stateless/h264/predictor.rs
+++ b/src/encoder/stateless/h264/predictor.rs
@@ -113,9 +113,13 @@ impl<Picture, Reference> LowDelayH264<Picture, Reference> {
             ((min_qp + max_qp) / 2) as u8
         };
 
+        // Use CABAC for better compression (not supported in Baseline profile)
+        let use_cabac = config.profile != Profile::Baseline;
+
         let pps = PpsBuilder::new(Rc::clone(&sps))
             .pic_parameter_set_id(0)
             .pic_init_qp(init_qp)
+            .entropy_coding_mode_flag(use_cabac)
             .deblocking_filter_control_present_flag(true)
             .num_ref_idx_l0_default_active(1)
             // Unused, P frame relies only on list0

--- a/src/encoder/stateless/h264/predictor.rs
+++ b/src/encoder/stateless/h264/predictor.rs
@@ -115,11 +115,17 @@ impl<Picture, Reference> LowDelayH264<Picture, Reference> {
 
         // Use CABAC for better compression (not supported in Baseline profile)
         let use_cabac = config.profile != Profile::Baseline;
+        // 8x8 transform improves compression (High profile and above)
+        let use_8x8_transform = matches!(
+            config.profile,
+            Profile::High | Profile::High10 | Profile::High422P
+        );
 
         let pps = PpsBuilder::new(Rc::clone(&sps))
             .pic_parameter_set_id(0)
             .pic_init_qp(init_qp)
             .entropy_coding_mode_flag(use_cabac)
+            .transform_8x8_mode_flag(use_8x8_transform)
             .deblocking_filter_control_present_flag(true)
             .num_ref_idx_l0_default_active(1)
             // Unused, P frame relies only on list0

--- a/src/encoder/stateless/h264/predictor.rs
+++ b/src/encoder/stateless/h264/predictor.rs
@@ -155,6 +155,7 @@ impl<Picture, Reference>
         let header = SliceHeaderBuilder::new(&pps)
             .slice_type(SliceType::I)
             .first_mb_in_slice(0)
+            .frame_num(dpb_meta.frame_num as u16)
             .pic_order_cnt_lsb(dpb_meta.poc)
             .build();
 
@@ -219,6 +220,7 @@ impl<Picture, Reference>
         let header = SliceHeaderBuilder::new(&pps)
             .slice_type(SliceType::P)
             .first_mb_in_slice(0)
+            .frame_num(dpb_meta.frame_num as u16)
             .pic_order_cnt_lsb(dpb_meta.poc)
             .build();
 


### PR DESCRIPTION
I noticed decoding artifacts when screensharing from Linux to an Intel Macbook Pro via Discord. So I dug a bit into the H.264 bitstream headers to see what's non-conforming to trigger this in VideoToolbox. Only really reproduceable on Intel Macs, not on ARM-based Macs or any other clients I could test with.

1. Lack of frame numbers in slice header
  - c212f75bf65e6a78e2da602a56d57059d2948f85 Is the commit that fixes this and then I see no artifacts anymore.

While I was looking at the headers and comparing to other valid H.264 streams I also spotted 2 low-hanging fruits to improve encoder efficiency:

2. c06f72b7a82998d588c64dcb80944432b1369988 Use CABAC instead of CAVLC for entropy coding, if we are at least in Main profile.
3. 6ff117cad72c055802669e11a58b43990833f956 Enable 8x8 transform in High profile.

With those changes, I compared average VMAF before and after for the same bitrate of 8Mbits of the same asset: 10s of 1080p uncompressed recording from Helldivers 2 (complex frames and high motion)

- AMD Radeon Pro W7500 (Discrete): 81.6 -> 85.1. **+3.5**
  - In that case CABAC made all the difference. Enabling 8x8 didn't change anything.
- Intel Raptor Lake-P Iris Xe (Integrated): 68.4 -> 74.3 (CABAC) -> 77.0 (CABAC + 8x8). **+8.6**
