### PR TITLE
Add vaapi_dlopen feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ edition = "2021"
 default = []
 backend = ["anyhow", "byteorder", "thiserror", "crc32fast", "nix", "drm", "drm-fourcc", "zerocopy"]
 vaapi = ["libva", "backend"]
+vaapi_dlopen = ["vaapi", "libva/dlopen"]
 v4l2 = ["v4l2r", "backend"]
 gbm = ["dep:gbm", "gbm-sys"]
 h265 = []


### PR DESCRIPTION
Depends on https://github.com/discord/cros-libva/pull/2

This is needed for runtime linking to work correctly in binaries, such as gpu_encoder_helper. Otherwise the binary will link to `-lva -lva-drm` at build time and require that to run. Runtime linking is done with stubs before using cros-libva in Discord already.