### PR TITLE
Fixes and improvements for AV1 VAAPI encoding

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ vaapi_dlopen = ["vaapi", "libva/dlopen"]
 v4l2 = ["v4l2r", "backend"]
 gbm = ["dep:gbm", "gbm-sys"]
 h265 = []
-av1 = []
+av1 = ["libva/vendored"]
 c2-wrapper = ["backend"]
 
 [dependencies]

--- a/src/backend/vaapi/encoder.rs
+++ b/src/backend/vaapi/encoder.rs
@@ -166,8 +166,9 @@ where
     /// VA context used for encoding.
     context: Rc<Context>,
 
-    va_profile: VAProfile::Type,
-    entrypoint: VAEntrypoint::Type,
+    pub(crate) va_profile: VAProfile::Type,
+    pub(crate) entrypoint: VAEntrypoint::Type,
+    packed_headers: u32,
     scratch_pool: VaSurfacePool<()>,
     _phantom: PhantomData<(M, H)>,
 }
@@ -193,20 +194,39 @@ where
         let rt_format = format_map.rt_format;
         let entrypoint = if low_power { VAEntrypointEncSliceLP } else { VAEntrypointEncSlice };
 
-        let va_config = display.create_config(
-            vec![
-                libva::VAConfigAttrib {
-                    type_: libva::VAConfigAttribType::VAConfigAttribRTFormat,
-                    value: rt_format,
-                },
-                libva::VAConfigAttrib {
-                    type_: libva::VAConfigAttribType::VAConfigAttribRateControl,
-                    value: bitrate_control,
-                },
-            ],
-            va_profile,
-            entrypoint,
-        )?;
+        let mut config_attrs = vec![
+            libva::VAConfigAttrib {
+                type_: libva::VAConfigAttribType::VAConfigAttribRTFormat,
+                value: rt_format,
+            },
+            libva::VAConfigAttrib {
+                type_: libva::VAConfigAttribType::VAConfigAttribRateControl,
+                value: bitrate_control,
+            },
+        ];
+
+        // Query and set packed header support in the config (tells the driver which
+        // packed headers we will provide, so it knows not to generate them internally).
+        let mut packed_header_query = [libva::VAConfigAttrib {
+            type_: libva::VAConfigAttribType::VAConfigAttribEncPackedHeaders,
+            value: 0,
+        }];
+        display.get_config_attributes(va_profile, entrypoint, &mut packed_header_query)?;
+        let packed_headers = if packed_header_query[0].value != libva::VA_ATTRIB_NOT_SUPPORTED {
+            let desired = libva::VA_ENC_PACKED_HEADER_SEQUENCE
+                | libva::VA_ENC_PACKED_HEADER_PICTURE
+                | libva::VA_ENC_PACKED_HEADER_SLICE;
+            let supported = packed_header_query[0].value & desired;
+            config_attrs.push(libva::VAConfigAttrib {
+                type_: libva::VAConfigAttribType::VAConfigAttribEncPackedHeaders,
+                value: supported,
+            });
+            supported
+        } else {
+            0
+        };
+
+        let va_config = display.create_config(config_attrs, va_profile, entrypoint)?;
 
         let context = display.create_context::<M>(
             &va_config,
@@ -229,9 +249,10 @@ where
         Ok(Self {
             va_config,
             context,
-            scratch_pool,
             va_profile,
             entrypoint,
+            packed_headers,
+            scratch_pool,
             _phantom: Default::default(),
         })
     }
@@ -310,19 +331,8 @@ where
         Ok(true)
     }
 
-    pub(crate) fn supports_packed_header(&self, header: u32) -> StatelessBackendResult<bool> {
-        let display = self.context().display();
-        let mut attrs = [libva::VAConfigAttrib {
-            type_: libva::VAConfigAttribType::VAConfigAttribEncPackedHeaders,
-            value: 0,
-        }];
-
-        display.get_config_attributes(self.va_profile, self.entrypoint, &mut attrs)?;
-
-        if attrs[0].value == libva::VA_ATTRIB_NOT_SUPPORTED || (header & attrs[0].value) == 0 {
-            return Ok(false);
-        }
-        Ok(true)
+    pub(crate) fn supports_packed_header(&self, header: u32) -> bool {
+        (self.packed_headers & header) != 0
     }
 }
 

--- a/src/bitstream_utils.rs
+++ b/src/bitstream_utils.rs
@@ -469,11 +469,17 @@ pub struct BitWriter<W: Write> {
     out: W,
     nth_bit: u8,
     curr_byte: u8,
+    total_bits: usize,
 }
 
 impl<W: Write> BitWriter<W> {
     pub fn new(writer: W) -> Self {
-        Self { out: writer, curr_byte: 0, nth_bit: 0 }
+        Self { out: writer, curr_byte: 0, nth_bit: 0, total_bits: 0 }
+    }
+
+    /// Returns the total number of bits written so far.
+    pub fn total_bits(&self) -> usize {
+        self.total_bits
     }
 
     /// Writes fixed bit size integer (up to 32 bit)
@@ -499,6 +505,7 @@ impl<W: Write> BitWriter<W> {
     pub fn write_bit(&mut self, bit: bool) -> BitWriterResult<()> {
         self.curr_byte |= (bit as u8) << (7u8 - self.nth_bit);
         self.nth_bit += 1;
+        self.total_bits += 1;
 
         if self.nth_bit == 8 {
             self.out.write_all(&[self.curr_byte])?;

--- a/src/codec/av1/synthesizer.rs
+++ b/src/codec/av1/synthesizer.rs
@@ -96,9 +96,23 @@ impl From<std::io::Error> for SynthesizerError {
 
 pub type SynthesizerResult<T> = Result<T, SynthesizerError>;
 
+/// Bit offsets of key syntax elements within a frame header OBU.
+/// These offsets are relative to the start of the frame header OBU data
+/// (after OBU header and OBU size), measured in bits.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct FrameHeaderBitOffsets {
+    pub qindex_offset: u32,
+    pub loopfilter_offset: u32,
+    pub cdef_start_offset: u32,
+    pub cdef_param_size: u32,
+    /// Total bit length of the frame header OBU data (excluding OBU header + size).
+    pub frame_hdr_data_bits: u32,
+}
+
 pub struct Synthesizer<'o, O: private::ObuStruct, W: Write> {
     writer: ObuWriter<W>,
     obu: &'o O,
+    offsets: FrameHeaderBitOffsets,
 }
 
 impl<'o, O, W> Synthesizer<'o, O, W>
@@ -107,7 +121,7 @@ where
     W: Write,
 {
     fn new(writer: W, obu: &'o O) -> Self {
-        Self { writer: ObuWriter::new(writer), obu }
+        Self { writer: ObuWriter::new(writer), obu, offsets: Default::default() }
     }
 
     fn f<T: Into<u32>>(&mut self, bits: usize, value: T) -> SynthesizerResult<()> {
@@ -170,6 +184,14 @@ where
 
     fn obu_size(&mut self, size: u32) -> SynthesizerResult<()> {
         self.leb128(size)
+    }
+
+    /// Writes the OBU size with a padded leb128 encoding (minimum byte count).
+    /// The VA-API spec requires a 4-byte obu_size field for the frame header OBU
+    /// so the driver can rewrite it during rate control.
+    fn obu_size_padded(&mut self, size: u32, min_bytes: usize) -> SynthesizerResult<()> {
+        self.writer.write_leb128(size, min_bytes)?;
+        Ok(())
     }
 
     /// Writes AV1 5.3.4. Trailing bits syntax
@@ -658,6 +680,47 @@ where
         Ok(())
     }
 
+    /// Synthesize the frame header OBU and return bit offsets of key syntax elements.
+    /// The offsets are relative to the start of the frame header OBU data (after
+    /// OBU header + OBU size), suitable for use in VAEncPictureParameterBufferAV1.
+    pub fn synthesize_with_offsets(
+        obu: &'o FrameHeaderObu,
+        sequence: &'o SequenceHeaderObu,
+        mut writer: W,
+    ) -> SynthesizerResult<FrameHeaderBitOffsets> {
+        let mut s = Synthesizer::new(&mut writer, obu);
+
+        if obu.obu_header.obu_type != ObuType::FrameHeader {
+            s.invalid_element_value("obu_type")?;
+        }
+
+        s.obu_header(&obu.obu_header)?;
+
+        if !obu.obu_header.has_size_field {
+            s.frame_header_obu(sequence)?;
+            s.trailing_bits()?;
+            let offsets = s.offsets;
+            return Ok(offsets);
+        }
+
+        let mut buf = Vec::<u8>::new();
+        let mut buffered = Synthesizer::new(&mut buf, obu);
+        buffered.frame_header_obu(sequence)?;
+        buffered.trailing_bits()?;
+        let mut offsets = buffered.offsets;
+        offsets.frame_hdr_data_bits = buffered.writer.bits_written() as u32;
+        drop(buffered);
+
+        // VA-API requires a 4-byte obu_size field for the frame header OBU
+        // so the driver can rewrite it during rate control adjustments.
+        s.obu_size_padded(buf.len() as u32, 4)?;
+        drop(s);
+
+        writer.write_all(&buf)?;
+
+        Ok(offsets)
+    }
+
     /// Writes AV1 5.9.1. General frame header OBU syntax
     fn frame_header_obu(&mut self, sequence: &'o SequenceHeaderObu) -> SynthesizerResult<()> {
         self.uncompressed_header(sequence)
@@ -1057,6 +1120,7 @@ where
             return Ok(());
         }
 
+        self.offsets.loopfilter_offset = self.writer.bits_written() as u32;
         self.f(6, self.obu.loop_filter_params.loop_filter_level[0])?;
         self.f(6, self.obu.loop_filter_params.loop_filter_level[1])?;
         if sequence.num_planes > 1
@@ -1097,6 +1161,7 @@ where
 
     /// Writes AV1 5.9.12. Quantization params syntax
     fn quantization_params(&mut self, sequence: &'o SequenceHeaderObu) -> SynthesizerResult<()> {
+        self.offsets.qindex_offset = self.writer.bits_written() as u32;
         self.f(8, self.obu.quantization_params.base_q_idx)?;
         self.read_delta_q(self.obu.quantization_params.delta_q_y_dc)?;
         if sequence.num_planes > 1 {
@@ -1314,6 +1379,7 @@ where
             return Ok(());
         }
 
+        self.offsets.cdef_start_offset = self.writer.bits_written() as u32;
         self.f(2, self.obu.cdef_params.cdef_damping - 3)?;
         self.f(2, self.obu.cdef_params.cdef_bits)?;
 
@@ -1338,6 +1404,9 @@ where
                 self.f(2, cdef_uv_sec_strength)?;
             }
         }
+
+        self.offsets.cdef_param_size =
+            self.writer.bits_written() as u32 - self.offsets.cdef_start_offset;
 
         Ok(())
     }

--- a/src/codec/av1/writer.rs
+++ b/src/codec/av1/writer.rs
@@ -120,6 +120,11 @@ impl<W: Write> ObuWriter<W> {
     pub fn aligned(&self) -> bool {
         !self.0.has_data_pending()
     }
+
+    /// Returns the total number of bits written so far.
+    pub fn bits_written(&self) -> usize {
+        self.0.total_bits()
+    }
 }
 
 #[cfg(test)]

--- a/src/decoder/stateless/av1/vaapi.rs
+++ b/src/decoder/stateless/av1/vaapi.rs
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 use std::rc::Rc;
+use std::sync::Arc;
 
 use anyhow::anyhow;
 use anyhow::Context;
@@ -559,7 +560,7 @@ impl<V: VideoFrame> StatelessAV1DecoderBackend for VaapiBackend<V> {
 impl<V: VideoFrame> StatelessDecoder<Av1, VaapiBackend<V>> {
     // Creates a new instance of the decoder using the VAAPI backend.
     pub fn new_vaapi(
-        display: Rc<Display>,
+        display: Arc<Display>,
         blocking_mode: BlockingMode,
     ) -> Result<Self, NewStatelessDecoderError> {
         Self::new(VaapiBackend::new(display, true), blocking_mode)

--- a/src/encoder/stateless/av1.rs
+++ b/src/encoder/stateless/av1.rs
@@ -10,7 +10,7 @@ use crate::codec::av1::parser::SequenceHeaderObu;
 use crate::codec::av1::parser::REFS_PER_FRAME;
 use crate::encoder::av1::EncoderConfig;
 use crate::encoder::av1::AV1;
-use crate::encoder::stateless::av1::predictor::LowDelayAV1;
+use crate::encoder::stateless::av1::predictor::{EncoderFeaturesAV1, LowDelayAV1};
 use crate::encoder::stateless::BitstreamPromise;
 use crate::encoder::stateless::Predictor;
 use crate::encoder::stateless::StatelessBackendResult;
@@ -123,9 +123,16 @@ impl<Handle, Backend> StatelessEncoder<Handle, Backend>
 where
     Backend: StatelessAV1EncoderBackend,
 {
-    fn new_av1(backend: Backend, config: EncoderConfig, mode: BlockingMode) -> EncodeResult<Self> {
+    fn new_av1(
+        backend: Backend,
+        config: EncoderConfig,
+        mode: BlockingMode,
+        av1_features: EncoderFeaturesAV1,
+    ) -> EncodeResult<Self> {
         let predictor: Box<dyn Predictor<_, _, _>> = match config.pred_structure {
-            PredictionStructure::LowDelay { limit } => Box::new(LowDelayAV1::new(config, limit)),
+            PredictionStructure::LowDelay { limit } => {
+                Box::new(LowDelayAV1::new(config, limit, av1_features))
+            }
         };
 
         Self::new(backend, mode, predictor)

--- a/src/encoder/stateless/av1/predictor.rs
+++ b/src/encoder/stateless/av1/predictor.rs
@@ -29,7 +29,6 @@ use crate::encoder::stateless::av1::BackendRequest;
 use crate::encoder::stateless::av1::EncoderConfig;
 use crate::encoder::stateless::predictor::LowDelay;
 use crate::encoder::stateless::predictor::LowDelayDelegate;
-use crate::encoder::EncodeError;
 use crate::encoder::EncodeResult;
 use crate::encoder::FrameMetadata;
 use crate::encoder::RateControl;
@@ -39,35 +38,80 @@ use crate::encoder::Tunings;
 pub(crate) const MIN_BASE_QINDEX: u32 = 0;
 pub(crate) const MAX_BASE_QINDEX: u32 = 255;
 
+/// AV1 encoder features queried from the driver.
+/// Used by the predictor to condition sequence/frame header parameters.
+#[derive(Debug, Clone)]
+pub(crate) struct EncoderFeaturesAV1 {
+    pub support_128x128_superblock: bool,
+    pub support_filter_intra: bool,
+    pub support_intra_edge_filter: bool,
+    pub support_interintra_compound: bool,
+    pub support_masked_compound: bool,
+    pub support_warped_motion: bool,
+    pub support_dual_filter: bool,
+    pub support_jnt_comp: bool,
+    pub support_ref_frame_mvs: bool,
+    pub support_superres: bool,
+    pub support_restoration: bool,
+    /// Bitmask of supported tx modes: bit 0 = ONLY_4X4, bit 1 = LARGEST, bit 2 = SELECT
+    pub tx_mode_support: u8,
+    #[allow(dead_code)]
+    pub max_tile_num_minus1: u16,
+}
+
+impl Default for EncoderFeaturesAV1 {
+    fn default() -> Self {
+        Self {
+            support_128x128_superblock: false,
+            support_filter_intra: false,
+            support_intra_edge_filter: false,
+            support_interintra_compound: false,
+            support_masked_compound: false,
+            support_warped_motion: false,
+            support_dual_filter: false,
+            support_jnt_comp: false,
+            support_ref_frame_mvs: false,
+            support_superres: false,
+            support_restoration: false,
+            tx_mode_support: 0x04, // Assume TX_MODE_SELECT
+            max_tile_num_minus1: 0,
+        }
+    }
+}
+
 pub(crate) struct LowDelayAV1Delegate {
     /// Current sequence header obu
     sequence: SequenceHeaderObu,
 
     /// Encoder config
     config: EncoderConfig,
+
+    /// AV1 encoder features queried from the driver.
+    features: EncoderFeaturesAV1,
 }
 
 pub(crate) type LowDelayAV1<Picture, Reference> =
     LowDelay<Picture, Reference, LowDelayAV1Delegate, BackendRequest<Picture, Reference>>;
 
 impl<Picture, Reference> LowDelayAV1<Picture, Reference> {
-    pub fn new(config: EncoderConfig, limit: u16) -> Self {
+    pub fn new(config: EncoderConfig, limit: u16, features: EncoderFeaturesAV1) -> Self {
+        let sequence = Self::create_sequence_header(&config, &features);
         Self {
             queue: Default::default(),
             references: Default::default(),
             counter: 0,
             limit,
             tunings: config.initial_tunings.clone(),
-            delegate: LowDelayAV1Delegate {
-                sequence: Self::create_sequence_header(&config),
-                config,
-            },
+            delegate: LowDelayAV1Delegate { sequence, config, features },
             tunings_queue: Default::default(),
             _phantom: Default::default(),
         }
     }
 
-    fn create_sequence_header(config: &EncoderConfig) -> SequenceHeaderObu {
+    fn create_sequence_header(
+        config: &EncoderConfig,
+        features: &EncoderFeaturesAV1,
+    ) -> SequenceHeaderObu {
         let width = config.resolution.width;
         let height = config.resolution.height;
 
@@ -97,12 +141,26 @@ impl<Picture, Reference> LowDelayAV1<Picture, Reference> {
 
             seq_force_integer_mv: SELECT_INTEGER_MV as u32,
 
+            // Gate features based on driver capabilities
+            use_128x128_superblock: features.support_128x128_superblock,
+            enable_filter_intra: features.support_filter_intra,
+            enable_intra_edge_filter: features.support_intra_edge_filter,
+            enable_interintra_compound: features.support_interintra_compound,
+            enable_masked_compound: features.support_masked_compound,
+            enable_warped_motion: features.support_warped_motion,
+            enable_dual_filter: features.support_dual_filter,
+            enable_jnt_comp: features.support_jnt_comp,
+            enable_ref_frame_mvs: features.support_ref_frame_mvs,
+            enable_superres: features.support_superres,
+            enable_cdef: true,
+            enable_restoration: features.support_restoration,
+
             operating_points: {
                 let mut ops: [OperatingPoint; MAX_NUM_OPERATING_POINTS] = Default::default();
                 ops[0].idc = 0;
-                // Use highest level 23 for now.
-                // TODO(bgrzesik): approximate level base on resolution and framerate
-                ops[0].seq_level_idx = 23;
+                // Let the driver pick the appropriate level by using 0 (2.0).
+                // The driver will override if needed based on the actual encoding parameters.
+                ops[0].seq_level_idx = 0;
                 ops
             },
 
@@ -135,6 +193,7 @@ impl<Picture, Reference> LowDelayAV1<Picture, Reference> {
     fn create_frame_header(&self, frame_type: FrameType) -> EncodeResult<FrameHeaderObu> {
         let width = self.delegate.config.resolution.width;
         let height = self.delegate.config.resolution.height;
+        let features = &self.delegate.features;
 
         // Superblock size
         let sb_size = if self.delegate.sequence.use_128x128_superblock { 128 } else { 64 };
@@ -143,16 +202,16 @@ impl<Picture, Reference> LowDelayAV1<Picture, Reference> {
         let order_hint_mask = (1 << self.delegate.sequence.order_hint_bits) - 1;
         let order_hint = (self.counter & order_hint_mask) as u32;
 
-        let RateControl::ConstantQuality(base_q_idx) = self.tunings.rate_control else {
-            return Err(EncodeError::Unsupported);
-        };
-
-        // Clamp tunings's quaility range to correct range
+        // Clamp tunings's quality range to correct range
         let min_q_idx = self.tunings.min_quality.max(MIN_BASE_QINDEX);
         let max_q_idx = self.tunings.max_quality.min(MAX_BASE_QINDEX);
 
-        // Clamp Q index
-        let base_q_idx = base_q_idx.clamp(min_q_idx, max_q_idx);
+        // For CQP mode, use the specified QP. For bitrate-controlled modes (VBR/CBR),
+        // the driver controls QP so we use a sensible default initial QP.
+        let base_q_idx = match self.tunings.rate_control {
+            RateControl::ConstantQuality(qp) => qp.clamp(min_q_idx, max_q_idx),
+            _ => (min_q_idx + max_q_idx) / 2,
+        };
 
         // Set the frame size in superblocks for the only tile
         let mut width_in_sbs_minus_1 = [0u32; MAX_TILE_COLS];
@@ -160,6 +219,17 @@ impl<Picture, Reference> LowDelayAV1<Picture, Reference> {
 
         let mut height_in_sbs_minus_1 = [0u32; MAX_TILE_ROWS];
         height_in_sbs_minus_1[0] = ((height + sb_size - 1) / sb_size) - 1;
+
+        // Select tx_mode based on driver capabilities
+        let tx_mode = if features.tx_mode_support & 0x04 != 0 {
+            TxMode::Select
+        } else if features.tx_mode_support & 0x02 != 0 {
+            TxMode::Largest
+        } else {
+            log::warn!("No preferred tx mode supported by driver, falling back to Select");
+            TxMode::Select
+        };
+        let tx_mode_select = if matches!(tx_mode, TxMode::Select) { 1 } else { 0 };
 
         Ok(FrameHeaderObu {
             obu_header: ObuHeader {
@@ -186,9 +256,9 @@ impl<Picture, Reference> LowDelayAV1<Picture, Reference> {
             order_hint,
             ref_order_hint: [0, 0, 0, 0, 0, 0, 0, 0],
 
-            reduced_tx_set: true,
-            tx_mode_select: 1,
-            tx_mode: TxMode::Select,
+            reduced_tx_set: false,
+            tx_mode_select,
+            tx_mode,
 
             // Provide the Q index from config
             quantization_params: QuantizationParams { base_q_idx, ..Default::default() },

--- a/src/encoder/stateless/av1/vaapi.rs
+++ b/src/encoder/stateless/av1/vaapi.rs
@@ -4,6 +4,7 @@
 
 use std::num::TryFromIntError;
 use std::rc::Rc;
+use std::sync::Arc;
 
 use libva::AV1EncLoopFilterFlags;
 use libva::AV1EncLoopRestorationFlags;
@@ -12,7 +13,10 @@ use libva::AV1EncPictureFlags;
 use libva::AV1EncQMatrixFlags;
 use libva::AV1EncSeqFields;
 use libva::AV1EncTileGroupObuHdrInfo;
+use libva::BufferType;
 use libva::EncCodedBuffer;
+use libva::EncPackedHeaderParameter;
+use libva::EncPackedHeaderType;
 use libva::EncPictureParameterBufferAV1;
 use libva::EncSegParamAV1;
 use libva::EncSegParamFlagsAV1;
@@ -27,19 +31,27 @@ use libva::VAProfile::VAProfileAV1Profile1;
 use libva::VaError;
 use libva::VA_INVALID_ID;
 
+use crate::backend::vaapi::encoder::tunings_to_libva_rc;
 use crate::backend::vaapi::encoder::CodedOutputPromise;
 use crate::backend::vaapi::encoder::Reconstructed;
 use crate::backend::vaapi::encoder::VaapiBackend;
+use crate::codec::av1::parser::FrameHeaderObu;
+use crate::codec::av1::parser::FrameType;
 use crate::codec::av1::parser::Profile;
 use crate::codec::av1::parser::ReferenceFrameType;
+use crate::codec::av1::parser::SequenceHeaderObu;
+use crate::codec::av1::parser::TemporalDelimiterObu;
 use crate::codec::av1::parser::CDEF_MAX;
 use crate::codec::av1::parser::MAX_SEGMENTS;
 use crate::codec::av1::parser::MAX_TILE_COLS;
 use crate::codec::av1::parser::MAX_TILE_ROWS;
 use crate::codec::av1::parser::REFS_PER_FRAME;
 use crate::codec::av1::parser::SEG_LVL_MAX;
+use crate::codec::av1::synthesizer::FrameHeaderBitOffsets;
+use crate::codec::av1::synthesizer::Synthesizer;
 use crate::encoder::av1::EncoderConfig;
 use crate::encoder::av1::AV1;
+use crate::encoder::stateless::av1::predictor::EncoderFeaturesAV1;
 use crate::encoder::stateless::av1::predictor::MAX_BASE_QINDEX;
 use crate::encoder::stateless::av1::predictor::MIN_BASE_QINDEX;
 use crate::encoder::stateless::av1::BackendRequest;
@@ -49,7 +61,6 @@ use crate::encoder::stateless::StatelessBackendError;
 use crate::encoder::stateless::StatelessBackendResult;
 use crate::encoder::stateless::StatelessEncoder;
 use crate::encoder::stateless::StatelessVideoEncoderBackend;
-use crate::encoder::EncodeError;
 use crate::encoder::EncodeResult;
 use crate::encoder::RateControl;
 use crate::video_frame::VideoFrame;
@@ -70,6 +81,8 @@ pub enum BackendError {
     RenderPictureError(VaError),
     #[error("vaRenderPicture failed: {0}")]
     EndPictureError(VaError),
+    #[error(transparent)]
+    Other(#[from] anyhow::Error),
 }
 
 impl From<BackendError> for StatelessBackendError {
@@ -79,6 +92,41 @@ impl From<BackendError> for StatelessBackendError {
 }
 
 type Result<T> = std::result::Result<T, BackendError>;
+
+/// Parse AV1 encoder features from the raw VAConfigAttribValEncAV1 u32 value.
+///
+/// Bit layout (each feature occupies 2 bits):
+///   [1:0]   128x128_superblock   [3:2]   filter_intra
+///   [5:4]   intra_edge_filter    [7:6]   interintra_compound
+///   [9:8]   masked_compound      [11:10] warped_motion
+///   [13:12] palette_mode         [15:14] dual_filter
+///   [17:16] jnt_comp             [19:18] ref_frame_mvs
+///   [21:20] superres             [23:22] restoration
+///   [25:24] allow_intrabc        [27:26] cdef_channel_strength
+fn parse_av1_enc_features(value: u32) -> EncoderFeaturesAV1 {
+    let bit = |shift: u32| -> bool { ((value >> shift) & 0x3) != 0 };
+
+    EncoderFeaturesAV1 {
+        support_128x128_superblock: bit(0),
+        support_filter_intra: bit(2),
+        support_intra_edge_filter: bit(4),
+        support_interintra_compound: bit(6),
+        support_masked_compound: bit(8),
+        support_warped_motion: bit(10),
+        support_dual_filter: bit(14),
+        support_jnt_comp: bit(16),
+        support_ref_frame_mvs: bit(18),
+        support_superres: bit(20),
+        support_restoration: bit(22),
+        ..Default::default()
+    }
+}
+
+/// Parse VAConfigAttribValEncAV1Ext2 fields into an existing features struct.
+fn apply_av1_enc_ext2(features: &mut EncoderFeaturesAV1, value: u32) {
+    features.tx_mode_support = ((value >> 4) & 0x7) as u8;
+    features.max_tile_num_minus1 = ((value >> 7) & 0x1fff) as u16;
+}
 
 impl<M, Handle> StatelessVideoEncoderBackend<AV1> for VaapiBackend<M, Handle>
 where
@@ -96,7 +144,52 @@ where
     M: SurfaceMemoryDescriptor,
     H: std::borrow::Borrow<Surface<M>> + 'static,
 {
-    fn build_seq_param(request: &Request<H>) -> Result<EncSequenceParameterBufferAV1> {
+    /// Query AV1 encoder capabilities from the driver using
+    /// VAConfigAttribEncAV1 and VAConfigAttribEncAV1Ext2.
+    fn query_av1_enc_features(&self) -> StatelessBackendResult<EncoderFeaturesAV1> {
+        let display = self.context().display();
+
+        // Query VAConfigAttribEncAV1 (features)
+        let mut attrs = [libva::VAConfigAttrib {
+            type_: libva::VAConfigAttribType::VAConfigAttribEncAV1,
+            value: 0,
+        }];
+
+        display.get_config_attributes(self.va_profile, self.entrypoint, &mut attrs)?;
+
+        let mut features = if attrs[0].value == libva::VA_ATTRIB_NOT_SUPPORTED {
+            log::warn!(
+                "Driver does not advertise AV1 encoder features, using conservative defaults"
+            );
+            EncoderFeaturesAV1::default()
+        } else {
+            log::info!("AV1 encoder features: {:#010x}", attrs[0].value);
+            parse_av1_enc_features(attrs[0].value)
+        };
+
+        // Query VAConfigAttribEncAV1Ext2 (tx_mode, tile_size_bytes, etc.)
+        let mut attrs = [libva::VAConfigAttrib {
+            type_: libva::VAConfigAttribType::VAConfigAttribEncAV1Ext2,
+            value: 0,
+        }];
+
+        display.get_config_attributes(self.va_profile, self.entrypoint, &mut attrs)?;
+
+        if attrs[0].value == libva::VA_ATTRIB_NOT_SUPPORTED {
+            log::warn!("Driver does not advertise AV1 encoder ext2 attributes, using defaults");
+        } else {
+            log::info!("AV1 encoder ext2: {:#010x}", attrs[0].value);
+            apply_av1_enc_ext2(&mut features, attrs[0].value);
+        }
+
+        log::info!("AV1 encoder features: {:?}", features);
+        Ok(features)
+    }
+
+    fn build_seq_param(
+        request: &Request<H>,
+        enable_cdef: bool,
+    ) -> Result<EncSequenceParameterBufferAV1> {
         assert!(
             request.sequence.operating_points_cnt_minus_1 == 0,
             "Only a single operating point is supported for now"
@@ -108,8 +201,7 @@ where
         let seq_tier = request.sequence.operating_points[OPERATING_POINT].seq_tier;
         let hierarchical_flag = 0;
 
-        // TODO: Enable bitrate control
-        let bits_per_second = 0;
+        let bits_per_second = request.tunings.rate_control.bitrate_maximum().unwrap_or(0) as u32;
 
         // AV1 5.5.2
         let bit_depth_minus8 = if request.sequence.seq_profile == Profile::Profile2
@@ -149,7 +241,7 @@ where
                 request.sequence.enable_jnt_comp,
                 request.sequence.enable_ref_frame_mvs,
                 request.sequence.enable_superres,
-                request.sequence.enable_cdef,
+                enable_cdef,
                 request.sequence.enable_restoration,
                 bit_depth_minus8,
                 request.sequence.color_config.subsampling_x,
@@ -184,6 +276,9 @@ where
         request: &Request<H>,
         recon: &Reconstructed,
         coded: &EncCodedBuffer,
+        fh_offsets: &FrameHeaderBitOffsets,
+        packed_seq_data_len: usize,
+        use_packed_headers: bool,
     ) -> Result<EncPictureParameterBufferAV1> {
         let coded_buf = coded.id();
         let reconstructed_frame = recon.surface_id();
@@ -250,7 +345,13 @@ where
         let filter_level_u = request.frame.loop_filter_params.loop_filter_level[2];
         let filter_level_v = request.frame.loop_filter_params.loop_filter_level[3];
 
-        let superres_scale_denominator = u8::try_from(request.frame.superres_denom)?;
+        // VAAPI expects 0 when superres is not used, even though the AV1 bitstream uses
+        // SUPERRES_NUM (8).
+        let superres_scale_denominator = if request.frame.use_superres {
+            u8::try_from(request.frame.superres_denom)?
+        } else {
+            0
+        };
 
         let interpolation_filter = request.frame.interpolation_filter as u8;
 
@@ -266,7 +367,7 @@ where
         let v_dc_delta_q = i8::try_from(request.frame.quantization_params.delta_q_v_dc)?;
         let v_ac_delta_q = i8::try_from(request.frame.quantization_params.delta_q_v_ac)?;
 
-        // Clamp tunings's quaility range to correct range
+        // Clamp quality range
         let min_base_qindex = request.tunings.min_quality.max(MIN_BASE_QINDEX);
         let min_base_qindex = u8::try_from(min_base_qindex)?;
         let max_base_qindex = request.tunings.max_quality.min(MAX_BASE_QINDEX);
@@ -348,16 +449,35 @@ where
         // Warped motion params
         let wm = [Default::default(); REFS_PER_FRAME];
 
-        // Ignore by driver
-        const BIT_OFFSET_QINDEX: u32 = 0;
-        const BIT_OFFSET_SEGMENTATION: u32 = 0;
-        const BIT_OFFSET_LOOPFILTER_PARAMS: u32 = 0;
-        const BIT_OFFSET_CDEF_PARAMS: u32 = 0;
-        const SIZE_IN_BITS_CDEF_PARAMS: u32 = 0;
+        // Bit offsets of key syntax elements within the packed frame header data.
+        // Per VA-API spec, offsets are "from the start of the packed header data"
+        // which includes the OBU header and 4-byte OBU size field.
+        // These are needed by the driver for rate control (to modify QP, CDEF, etc.).
+        // When packed headers are not used, all offsets are 0.
+        let mut bit_offset_qindex = 0u32;
+        let bit_offset_segmentation = 0u32;
+        let mut bit_offset_loopfilter_params = 0u32;
+        let mut bit_offset_cdef_params = 0u32;
+        let mut size_in_bits_cdef_params = 0u32;
+        let mut byte_offset_frame_hdr_obu_size = 0u32;
+        let mut size_in_bits_frame_hdr_obu = 0u32;
 
-        // TODO: use packed header and fill for bitrate control
-        const BYTE_OFFSET_FRAME_HDR_OBU_SIZE: u32 = 0;
-        const SIZE_IN_BITS_FRAME_HDR_OBU: u32 = 0;
+        if use_packed_headers {
+            let obu_header_bytes: u32 = if request.frame.obu_header.extension_flag { 2 } else { 1 };
+            const OBU_SIZE_BYTES: u32 = 4; // VA-API requires 4-byte leb128 obu_size
+            let prefix_bits = (obu_header_bytes + OBU_SIZE_BYTES) * 8;
+
+            bit_offset_qindex = prefix_bits + fh_offsets.qindex_offset;
+            bit_offset_loopfilter_params = prefix_bits + fh_offsets.loopfilter_offset;
+            if fh_offsets.cdef_start_offset > 0 {
+                bit_offset_cdef_params = prefix_bits + fh_offsets.cdef_start_offset;
+            }
+            size_in_bits_cdef_params = fh_offsets.cdef_param_size;
+            // For IDR frames, the driver concatenates packed SH + FH data,
+            // so byte_offset_frame_hdr_obu_size must include the SH data length.
+            byte_offset_frame_hdr_obu_size = packed_seq_data_len as u32 + obu_header_bytes;
+            size_in_bits_frame_hdr_obu = prefix_bits + fh_offsets.frame_hdr_data_bits;
+        }
 
         let temporal_id = u8::try_from(request.frame.obu_header.temporal_id)?;
         let spatial_id = u8::try_from(request.frame.obu_header.spatial_id)?;
@@ -461,13 +581,13 @@ where
                 lr_uv_shift,
             ),
             wm,
-            BIT_OFFSET_QINDEX,
-            BIT_OFFSET_SEGMENTATION,
-            BIT_OFFSET_LOOPFILTER_PARAMS,
-            BIT_OFFSET_CDEF_PARAMS,
-            SIZE_IN_BITS_CDEF_PARAMS,
-            BYTE_OFFSET_FRAME_HDR_OBU_SIZE,
-            SIZE_IN_BITS_FRAME_HDR_OBU,
+            bit_offset_qindex,
+            bit_offset_segmentation,
+            bit_offset_loopfilter_params,
+            bit_offset_cdef_params,
+            size_in_bits_cdef_params,
+            byte_offset_frame_hdr_obu_size,
+            size_in_bits_frame_hdr_obu,
             &AV1EncTileGroupObuHdrInfo::new(
                 request.frame.obu_header.extension_flag,
                 request.frame.obu_header.has_size_field,
@@ -483,6 +603,45 @@ where
         // Single tile is only supported for now.
         EncTileGroupBufferAV1::new(0, 0)
     }
+
+    /// Build packed sequence header (sequence header OBU) for keyframes.
+    fn build_packed_sequence_header(
+        sequence: &SequenceHeaderObu,
+    ) -> Result<(BufferType, BufferType)> {
+        let mut buffer = Vec::new();
+        Synthesizer::<'_, SequenceHeaderObu, _>::synthesize(sequence, &mut buffer)
+            .map_err(|e| BackendError::Other(anyhow::anyhow!("{}", e)))?;
+        let length_in_bits = (buffer.len() * 8) as u32;
+        let packed_param = BufferType::EncPackedHeaderParameter(EncPackedHeaderParameter::new(
+            EncPackedHeaderType::Sequence,
+            length_in_bits,
+            true, // has_emulation_bytes
+        ));
+        let packed_data = BufferType::EncPackedHeaderData(buffer);
+        Ok((packed_param, packed_data))
+    }
+
+    /// Build packed frame header (frame header OBU) and return bit offsets.
+    fn build_packed_frame_header(
+        frame: &FrameHeaderObu,
+        sequence: &SequenceHeaderObu,
+    ) -> Result<(BufferType, BufferType, FrameHeaderBitOffsets)> {
+        let mut buffer = Vec::new();
+        let offsets = Synthesizer::<'_, FrameHeaderObu, _>::synthesize_with_offsets(
+            frame,
+            sequence,
+            &mut buffer,
+        )
+        .map_err(|e| BackendError::Other(anyhow::anyhow!("{}", e)))?;
+        let length_in_bits = (buffer.len() * 8) as u32;
+        let packed_param = BufferType::EncPackedHeaderParameter(EncPackedHeaderParameter::new(
+            EncPackedHeaderType::Picture,
+            length_in_bits,
+            true, // has_emulation_bytes
+        ));
+        let packed_data = BufferType::EncPackedHeaderData(buffer);
+        Ok((packed_param, packed_data, offsets))
+    }
 }
 
 impl<M, H> StatelessAV1EncoderBackend for VaapiBackend<M, H>
@@ -497,13 +656,12 @@ where
         let coded_buf = self.new_coded_buffer(&request.tunings.rate_control)?;
         let recon = self.new_scratch_picture()?;
 
-        let seq_param = Self::build_seq_param(&request)?;
+        // Use the sequence header's enable_cdef setting (always true since predictor enables it).
+        let enable_cdef = request.sequence.enable_cdef;
+
+        let seq_param = Self::build_seq_param(&request, enable_cdef)?;
         let seq_param =
             libva::BufferType::EncSequenceParameter(libva::EncSequenceParameter::AV1(seq_param));
-
-        let pic_param = Self::build_pic_param(&request, &recon, &coded_buf)?;
-        let pic_param =
-            libva::BufferType::EncPictureParameter(libva::EncPictureParameter::AV1(pic_param));
 
         let tg_param = Self::build_tile_group_param();
         let tg_param =
@@ -519,12 +677,116 @@ where
             references.push(ref_frame.clone() as Rc<dyn std::any::Any>);
         }
 
+        // Build packed headers if the driver supports them.
+        // We build packed_pic first to get bit offsets needed by the picture parameter.
+        let is_keyframe = matches!(request.frame.frame_type, FrameType::KeyFrame);
+
+        let packed_seq = if is_keyframe {
+            if self.supports_packed_header(libva::VA_ENC_PACKED_HEADER_SEQUENCE) {
+                Some(Self::build_packed_sequence_header(&request.sequence)?)
+            } else {
+                None
+            }
+        } else {
+            None
+        };
+
+        let (packed_pic, fh_offsets) =
+            if self.supports_packed_header(libva::VA_ENC_PACKED_HEADER_PICTURE) {
+                let (param, data, offsets) =
+                    Self::build_packed_frame_header(&request.frame, &request.sequence)?;
+                (Some((param, data)), offsets)
+            } else {
+                (None, Default::default())
+            };
+
+        let use_packed_headers = packed_seq.is_some() || packed_pic.is_some();
+
+        // For IDR frames, the driver concatenates packed SH + FH data,
+        // so byte_offset_frame_hdr_obu_size must include the SH data length.
+        let packed_seq_data_len = packed_seq.as_ref().map_or(0, |(_, data)| {
+            if let BufferType::EncPackedHeaderData(bytes) = data {
+                bytes.len()
+            } else {
+                0
+            }
+        });
+
+        let pic_param = Self::build_pic_param(
+            &request,
+            &recon,
+            &coded_buf,
+            &fh_offsets,
+            packed_seq_data_len,
+            use_packed_headers,
+        )?;
+        let pic_param =
+            libva::BufferType::EncPictureParameter(libva::EncPictureParameter::AV1(pic_param));
+
         let mut picture =
             Picture::new(request.input_meta.timestamp, Rc::clone(self.context()), request.input);
 
+        // Buffer ordering: Seq, RC, HRD, FrameRate, Pic, PackedSeq, PackedPic, TileGroup
         picture.add_buffer(self.context().create_buffer(seq_param)?);
+
+        let rc_param =
+            tunings_to_libva_rc::<{ MIN_BASE_QINDEX }, { MAX_BASE_QINDEX }>(&request.tunings)?;
+        let rc_param =
+            libva::BufferType::EncMiscParameter(libva::EncMiscParameter::RateControl(rc_param));
+        picture.add_buffer(self.context().create_buffer(rc_param)?);
+
+        // For rate-controlled modes, always send HRD parameters.
+        // Use explicit rc_buffer_size if set, otherwise default to max bitrate.
+        let hrd_buffer_size = request
+            .tunings
+            .rc_buffer_size
+            .or_else(|| request.tunings.rate_control.bitrate_maximum().map(|b| b as u32));
+        if let Some(hrd_buffer_size) = hrd_buffer_size {
+            let hrd_buffer_fullness = hrd_buffer_size * 3 / 4;
+
+            let hrd_param = libva::BufferType::EncMiscParameter(libva::EncMiscParameter::HRD(
+                libva::EncMiscParameterHRD::new(hrd_buffer_fullness, hrd_buffer_size),
+            ));
+            picture.add_buffer(self.context().create_buffer(hrd_param)?);
+        }
+
+        let framerate_param =
+            libva::BufferType::EncMiscParameter(libva::EncMiscParameter::FrameRate(
+                libva::EncMiscParameterFrameRate::new(request.tunings.framerate, 0),
+            ));
+        picture.add_buffer(self.context().create_buffer(framerate_param)?);
         picture.add_buffer(self.context().create_buffer(pic_param)?);
+
+        if let Some((packed_param, packed_data)) = packed_seq {
+            picture.add_buffer(self.context().create_buffer(packed_param)?);
+            picture.add_buffer(self.context().create_buffer(packed_data)?);
+        }
+
+        if let Some((packed_param, packed_data)) = packed_pic {
+            picture.add_buffer(self.context().create_buffer(packed_param)?);
+            picture.add_buffer(self.context().create_buffer(packed_data)?);
+        }
         picture.add_buffer(self.context().create_buffer(tg_param)?);
+
+        if let Some(max_frame_size) = request.tunings.max_frame_size {
+            if self.supports_max_frame_size()? {
+                let max_frame_size_param =
+                    libva::BufferType::EncMiscParameter(libva::EncMiscParameter::MaxFrameSize(
+                        libva::EncMiscParameterBufferMaxFrameSize::new(max_frame_size),
+                    ));
+                picture.add_buffer(self.context().create_buffer(max_frame_size_param)?);
+            }
+        }
+
+        if let Some(quality) = request.tunings.quality {
+            if self.supports_quality_range(quality)? {
+                let quality_param =
+                    libva::BufferType::EncMiscParameter(libva::EncMiscParameter::QualityLevel(
+                        libva::EncMiscParameterBufferQualityLevel::new(quality),
+                    ));
+                picture.add_buffer(self.context().create_buffer(quality_param)?);
+            }
+        }
 
         // Start processing the picture encoding
         let picture = picture.begin().map_err(BackendError::BeginPictureError)?;
@@ -535,44 +797,101 @@ where
         // Therefore return the reconstructed frame immediately.
         let reference_promise = ReadyPromise::from(recon);
 
+        // When using packed headers, the driver includes the headers in its output.
+        // We only need to prepend the temporal delimiter OBU.
+        // When NOT using packed headers, use the full coded_output from the predictor
+        // (which contains TD + SH + FH).
+        let coded_output = if use_packed_headers {
+            use crate::codec::av1::parser::ObuHeader;
+            use crate::codec::av1::parser::ObuType;
+            let mut td_buf = Vec::new();
+            let td = TemporalDelimiterObu {
+                obu_header: ObuHeader {
+                    obu_type: ObuType::TemporalDelimiter,
+                    extension_flag: false,
+                    has_size_field: true,
+                    temporal_id: 0,
+                    spatial_id: 0,
+                },
+            };
+            Synthesizer::<'_, TemporalDelimiterObu, _>::synthesize(&td, &mut td_buf)
+                .map_err(|e| StatelessBackendError::Other(anyhow::anyhow!("{}", e)))?;
+            td_buf
+        } else {
+            request.coded_output
+        };
+
         let bitstream_promise =
-            CodedOutputPromise::new(picture, references, coded_buf, request.coded_output);
+            CodedOutputPromise::new(picture, references, coded_buf, coded_output);
 
         Ok((reference_promise, bitstream_promise))
     }
+}
+
+/// Create the VAAPI backend and query AV1 encoder features from the driver.
+/// Shared setup logic for both `new_vaapi` and `new_native_vaapi`.
+fn create_av1_vaapi_backend<D, S>(
+    display: Arc<libva::Display>,
+    config: &EncoderConfig,
+    fourcc: Fourcc,
+    coded_size: Resolution,
+    low_power: bool,
+) -> EncodeResult<(VaapiBackend<D, S>, EncoderFeaturesAV1)>
+where
+    D: SurfaceMemoryDescriptor,
+    S: std::borrow::Borrow<Surface<D>> + 'static,
+{
+    let va_profile = match config.profile {
+        Profile::Profile0 => VAProfileAV1Profile0,
+        Profile::Profile1 => VAProfileAV1Profile1,
+        _ => return Err(StatelessBackendError::UnsupportedProfile.into()),
+    };
+
+    let bitrate_control = match config.initial_tunings.rate_control {
+        RateControl::ConstantBitrate(_) => libva::VA_RC_CBR,
+        RateControl::VariableBitrate { .. } => libva::VA_RC_VBR,
+        RateControl::ConstantQuality(_) => libva::VA_RC_CQP,
+    };
+
+    let backend =
+        VaapiBackend::new(display, va_profile, fourcc, coded_size, bitrate_control, low_power)?;
+
+    let av1_features = backend.query_av1_enc_features()?;
+
+    Ok((backend, av1_features))
 }
 
 impl<V: VideoFrame>
     StatelessEncoder<AV1, V, VaapiBackend<V::MemDescriptor, Surface<V::MemDescriptor>>>
 {
     pub fn new_vaapi(
-        display: Rc<libva::Display>,
+        display: Arc<libva::Display>,
         config: EncoderConfig,
         fourcc: Fourcc,
         coded_size: Resolution,
         low_power: bool,
         blocking_mode: BlockingMode,
     ) -> EncodeResult<Self> {
-        let va_profile = match config.profile {
-            Profile::Profile0 => VAProfileAV1Profile0,
-            Profile::Profile1 => VAProfileAV1Profile1,
-            _ => return Err(StatelessBackendError::UnsupportedProfile.into()),
-        };
+        let (backend, av1_features) =
+            create_av1_vaapi_backend(display, &config, fourcc, coded_size, low_power)?;
+        Self::new_av1(backend, config, blocking_mode, av1_features)
+    }
+}
 
-        if !matches!(config.initial_tunings.rate_control, RateControl::ConstantQuality(_)) {
-            return Err(EncodeError::Unsupported);
-        }
-
-        let backend = VaapiBackend::new(
-            display,
-            va_profile,
-            fourcc,
-            coded_size,
-            libva::VA_RC_CQP,
-            low_power,
-        )?;
-
-        Self::new_av1(backend, config, blocking_mode)
+impl<D: SurfaceMemoryDescriptor, S: std::borrow::Borrow<Surface<D>> + 'static>
+    StatelessEncoder<AV1, S, VaapiBackend<D, S>>
+{
+    pub fn new_native_vaapi(
+        display: Arc<libva::Display>,
+        config: EncoderConfig,
+        fourcc: Fourcc,
+        coded_size: Resolution,
+        low_power: bool,
+        blocking_mode: BlockingMode,
+    ) -> EncodeResult<Self> {
+        let (backend, av1_features) =
+            create_av1_vaapi_backend(display, &config, fourcc, coded_size, low_power)?;
+        Self::new_av1(backend, config, blocking_mode, av1_features)
     }
 }
 
@@ -651,7 +970,7 @@ mod tests {
         let low_power = entrypoints.contains(&VAEntrypointEncSliceLP);
 
         let mut backend = VaapiBackend::<Descriptor, Surface>::new(
-            Rc::clone(&display),
+            Arc::clone(&display),
             VAProfileAV1Profile0,
             fourcc,
             Resolution { width: WIDTH, height: HEIGHT },
@@ -868,7 +1187,7 @@ mod tests {
         };
 
         let mut encoder = VaapiAv1Encoder::new_vaapi(
-            Rc::clone(&display),
+            Arc::clone(&display),
             config,
             frame_layout.format.0,
             frame_layout.size,
@@ -878,7 +1197,7 @@ mod tests {
         .unwrap();
 
         let mut pool = VaSurfacePool::new(
-            Rc::clone(&display),
+            Arc::clone(&display),
             VA_RT_FORMAT_YUV420,
             Some(UsageHint::USAGE_HINT_ENCODER),
             Resolution { width: WIDTH as u32, height: HEIGHT as u32 },
@@ -959,7 +1278,7 @@ mod tests {
         };
 
         let mut encoder = VaapiAv1Encoder::new_vaapi(
-            Rc::clone(&display),
+            Arc::clone(&display),
             config,
             frame_layout.format.0,
             frame_layout.size,
@@ -969,7 +1288,7 @@ mod tests {
         .unwrap();
 
         let mut pool = VaSurfacePool::new(
-            Rc::clone(&display),
+            Arc::clone(&display),
             VA_RT_FORMAT_YUV420_10,
             Some(UsageHint::USAGE_HINT_ENCODER),
             Resolution { width: WIDTH as u32, height: HEIGHT as u32 },

--- a/src/encoder/stateless/h264/vaapi.rs
+++ b/src/encoder/stateless/h264/vaapi.rs
@@ -477,8 +477,8 @@ where
 
         // Packed SPS/PPS headers for IDR frames
         let packed_sps_pps_header_buffers = if request.is_idr {
-            let supports_sps = self.supports_packed_header(libva::VA_ENC_PACKED_HEADER_SEQUENCE)?;
-            let supports_pps = self.supports_packed_header(libva::VA_ENC_PACKED_HEADER_PICTURE)?;
+            let supports_sps = self.supports_packed_header(libva::VA_ENC_PACKED_HEADER_SEQUENCE);
+            let supports_pps = self.supports_packed_header(libva::VA_ENC_PACKED_HEADER_PICTURE);
 
             if supports_sps && supports_pps {
                 info!("Using packed SPS/PPS headers for IDR frame");
@@ -500,7 +500,7 @@ where
         let use_packed_sps_pps = packed_sps_pps_header_buffers.is_some();
 
         let packed_slice_header_buffers = if self
-            .supports_packed_header(libva::VA_ENC_PACKED_HEADER_SLICE)?
+            .supports_packed_header(libva::VA_ENC_PACKED_HEADER_SLICE)
         {
             Some(
                 Self::build_enc_packed_slice_param_and_data(&request)

--- a/src/encoder/stateless/predictor.rs
+++ b/src/encoder/stateless/predictor.rs
@@ -113,7 +113,10 @@ where
 
     fn increment_counter(&mut self) {
         let old_counter = self.counter;
-        self.counter = self.counter.wrapping_add(1) % (self.limit as usize);
+        self.counter = self.counter.wrapping_add(1);
+        if self.limit > 0 {
+            self.counter %= self.limit as usize;
+        }
 
         if self.counter == 0 && old_counter != 0 {
             // Counter wrapped around naturally at the limit


### PR DESCRIPTION
Depends on https://github.com/discord/cros-libva/pull/3

1. [fix division by 0 in predictor](https://github.com/discord/cros-codecs/commit/904fc8d33bb25d3fa6c787eaf807e0bf2990cffa)
2. [vaapi: cache packed header support in encoder backend](https://github.com/discord/cros-codecs/commit/9f28440acc47c76057d97fb259a35b9bf65dcf38) 

- Query and cache packed header capabilities at config creation
- Add packed headers bitmask to VAConfigAttrib during config setup
- Simplify supports_packed_header to use cached value

3. [av1: implement vaapi encoding improvements](https://github.com/discord/cros-codecs/commit/bb2d386b28c8cda1b3dc83c343209cb396b65b44) 

- Add packed header support for AV1 sequence and frame headers
- Probe AV1 features before using them
- Add total_bits tracking to BitWriter for OBU size calculation
- Improve AV1 predictor with rate control support

With those changes, AV1 VAAPI encoding can work in the Discord client. Tested with:
- AMD Radeon Pro W7500
- Lunar Lake (Intel Arc Graphics 130V / 140V)