### PR TITLE
vaapi: fixes for the h264 encoder

### DIFF
--- a/src/codec/h264/parser.rs
+++ b/src/codec/h264/parser.rs
@@ -1207,7 +1207,7 @@ impl SpsBuilder {
     }
 
     pub fn max_frame_num(self, value: u32) -> Self {
-        self.log2_max_frame_num_minus4(value.ilog2() as u8 - 4u8)
+        self.log2_max_frame_num_minus4(value.next_power_of_two().ilog2().saturating_sub(4) as u8)
     }
 
     pub fn pic_order_cnt_type(mut self, value: u8) -> Self {
@@ -1221,7 +1221,9 @@ impl SpsBuilder {
     }
 
     pub fn max_pic_order_cnt_lsb(self, value: u32) -> Self {
-        self.log2_max_pic_order_cnt_lsb_minus4(value.ilog2() as u8 - 4u8)
+        self.log2_max_pic_order_cnt_lsb_minus4(
+            value.next_power_of_two().ilog2().saturating_sub(4) as u8
+        )
     }
 
     pub fn delta_pic_order_always_zero_flag(mut self, value: bool) -> Self {

--- a/src/encoder/stateless/h264/vaapi.rs
+++ b/src/encoder/stateless/h264/vaapi.rs
@@ -568,8 +568,6 @@ where
                         libva::EncMiscParameterBufferMaxFrameSize::new(max_frame_size as u32),
                     ));
                 picture.add_buffer(self.context().create_buffer(max_frame_size_param)?);
-            } else {
-                warn!("Max frame size not supported");
             }
         }
 
@@ -580,8 +578,6 @@ where
                         libva::EncMiscParameterBufferQualityLevel::new(quality),
                     ));
                 picture.add_buffer(self.context().create_buffer(quality_param)?);
-            } else {
-                warn!("Quality level not supported");
             }
         }
 

--- a/src/encoder/stateless/h264/vaapi.rs
+++ b/src/encoder/stateless/h264/vaapi.rs
@@ -556,7 +556,7 @@ where
             let hrd_buffer_fullness = hrd_buffer_size * 3 / 4;
 
             let hrd_param = BufferType::EncMiscParameter(libva::EncMiscParameter::HRD(
-                libva::EncMiscParameterHRD::new(hrd_buffer_size, hrd_buffer_fullness),
+                libva::EncMiscParameterHRD::new(hrd_buffer_fullness, hrd_buffer_size),
             ));
             picture.add_buffer(self.context().create_buffer(hrd_param)?);
         }


### PR DESCRIPTION
1. [h264: fix SPS builder log2 calculations](https://github.com/discord/cros-codecs/commit/dc75cc3d7e93fd5e55d7d4be70462442c2e028c8) 

Use saturating_sub instead to avoid underflow.

2. [vaapi: fix wrong order of hrd parameters in h264 encoder](https://github.com/discord/cros-codecs/commit/aea17c88ea68ba5b320cbc80a1709ed6d80ce421)

3. [vaapi: remove warnings in h264 encoder for unsupported features](https://github.com/discord/cros-codecs/commit/99d4e4ca37c52d36f0ea7fca9388ffbded46f2e3) 

If those features are unsupported, the log would repeat for every
frame, which is quite verbose